### PR TITLE
Add runtests invoke task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install pep8 pyflakes
+  - pip install pytest pep8 pyflakes
 script:
-  - pyflakes .
-  - pep8 --ignore E265,E266,E501 .
-  - pytest
+  - invoke runtests

--- a/docs/contribute-a-spider.md
+++ b/docs/contribute-a-spider.md
@@ -43,10 +43,15 @@ scrapy crawl cha
 
 ## Run the automated tests
 
-Run pytest:
+We use the [pytest](https://docs.pytest.org/en/latest/) testing framework to
+verify the behavior of the project's code and 
+[pyflakes](https://docs.pytest.org/en/latest/) and [pep8](https://pypi.python.org/pypi/pep8) to
+check that all code is written in the proper style.
+
+To run these tools, use the `invoke runtests` command:
 
 ```
-pytest
+invoke runtests
 ```
 
 Whoops! The tests fail by default. Here's typical output:

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,4 @@
-from invoke import task
+from invoke import task, run
 from jinja2 import Environment, FileSystemLoader
 import requests
 
@@ -37,6 +37,16 @@ def genspider(ctx, name, domain, start_urls=None):
         html_filenames = _gen_html(name, start_urls)
         for f in html_filenames:
             print('Created {0}'.format(f))
+
+
+@task
+def runtests(ctx):
+    """
+    Runs pytest, pyflakes, and pep8.
+    """
+    run('pytest', pty=True)
+    run('pyflakes .', pty=True)
+    run('pep8 --ignore E265,E266,E501 .', pty=True)
 
 
 def _make_classname(name):


### PR DESCRIPTION
I've added an invoke task that runs the tests and all style checkers in order to help developers follow the style guidelines used by the project. This should also help prevent the situation where a developer runs the tests locally and sees them pass only to have CI fail due to a style issue.

If there is a better name than `runtests`, I'm all ears!