### PR TITLE
Don't attempt to use pty=true if pty isn't available.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -52,15 +52,9 @@ def runtests(ctx):
     """
     Runs pytest, pyflakes, and pep8.
     """
-<<<<<<< windows-runtests
     run('pytest', pty=pty_available)
     run('pyflakes .', pty=pty_available)
     run('pep8 --ignore E265,E266,E501 .', pty=pty_available)
-=======
-    run('pytest -s', pty=True)
-    run('pyflakes .', pty=True)
-    run('pep8 --ignore E265,E266,E501 .', pty=True)
->>>>>>> master
 
 
 def _make_classname(name):

--- a/tasks.py
+++ b/tasks.py
@@ -38,15 +38,23 @@ def genspider(ctx, name, domain, start_urls=None):
         for f in html_filenames:
             print('Created {0}'.format(f))
 
+# pty is not available on Windows
+try:
+    import pty
+    assert pty  # prevent pyflakes warning about unused import
+    pty_available = True
+except ImportError:
+    pty_available = False
+
 
 @task
 def runtests(ctx):
     """
     Runs pytest, pyflakes, and pep8.
     """
-    run('pytest', pty=True)
-    run('pyflakes .', pty=True)
-    run('pep8 --ignore E265,E266,E501 .', pty=True)
+    run('pytest', pty=pty_available)
+    run('pyflakes .', pty=pty_available)
+    run('pep8 --ignore E265,E266,E501 .', pty=pty_available)
 
 
 def _make_classname(name):


### PR DESCRIPTION
Hopefully fixes #62 by attempting to load the `pty` module to see if we're running on an OS that supports it.