### PR TITLE
Document event schema and writing tests

### DIFF
--- a/docs/contribute-a-spider.md
+++ b/docs/contribute-a-spider.md
@@ -177,4 +177,53 @@ class ChaSpider(scrapy.Spider):
 
 ## Write tests
 
-TK TK writing tests
+Our general approach to writing tests is to save a copy of a site's HTML in
+`tests/files` and then use that HTML to verify the behavior of each spider. In
+this way, we avoid needing a network connection to run tests and our tests
+don't break every time a site's content is updated.
+
+Here is the test setup and an example test from the Idph spider:
+
+```python
+import pytest
+
+from tests.utils import file_response
+from documenters_aggregator.spiders.idph import IdphSpider
+
+test_response = file_response('files/idph.html')
+spider = IdphSpider()
+parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
+
+
+def test_name():
+    assert parsed_items[2]['name'] == 'PAC: Maternal Mortality Review Committee Meeting'
+```
+
+It is also possible to execute a function over every element in the `parsed_items` list. In the following example, the `test_classification` function will be invoked once for each element in `parsed_items` list.
+
+```python
+@pytest.mark.parametrize('item', parsed_items)
+def test_classification(item):
+    assert item['classification'] == 'Not classified'
+```
+
+Parameterized test functions are best used to assert something about every event such as the existence of a field or a value all events will share.
+
+You can read more about parameterized test functions [in the pytest docs](https://docs.pytest.org/en/latest/parametrize.html#pytest-mark-parametrize).
+
+You generally want to verify that a spider:
+
+* Extracts the correct number of events from a page.
+* Extracts the correct values from a single event.
+* Parses any date and time values, combining them as needed.
+
+## Create a Pull Request
+
+If your ready to submit your code to the project, you should create a pull
+request on GitHub. You can do this as early as you would like in order to get
+feedback from others working on the project. In this case, please prefix your
+pull request name with `WIP` so that everyone knows what kind of feedback you
+are looking for.
+
+Additionally, please use the pull request description to explain anything you'd
+like a reviewer to know about the code.

--- a/docs/event_schema.md
+++ b/docs/event_schema.md
@@ -1,0 +1,36 @@
+# Event schema
+
+Our data model for events is based on the [Event Object](http://docs.opencivicdata.org/en/latest/data/event.html) from the [Open Civic Data](http://docs.opencivicdata.org) project.
+
+For our initial scrapers, we are focusing on basic event data. Over time, this
+may expand to include meeting notes, agendas, etc.
+
+```python
+{
+  '_type': 'event',                              # required value
+  'name': 'Committee on Pedestrian Safety',      # required string
+  'description': 'A longer description',         # optional string
+  'classification': 'committee-meeting'          # must be one of committee-meeting or hearing
+  'start_time': '2017-08-30T17:30:00Z',          # required datetime in UTC, using ISO8601 format
+  'end_time': None,                              # optional datetime in UTC, using ISO8601 format
+  'timezone': 'America/Chicago',                 # required timezone in tzinfo format
+  'all_day': False,                              # must be True or False
+  'status': 'tentative',                         # must be one of: cancelled, tentative, confirmed, passed
+
+  'location': {                                  # required dictionary
+    'url': '',                                   # optional URL of the location, not the event!
+    'name': 'Room 201A, City Hall, Chicago, IL', # required address of the location
+    'coordinates': {                             # must be: None or object
+      'latitude': '41.883868',                   # as a string!
+      'longitude': '-87.631936'                  # as a string!
+    }
+  },
+
+  'sources': [                                   # required list of sources
+    {
+      'url': '',                                 # required URL where data was scraped from
+      'note': ''                                 # optional info about how the data was scraped
+    }
+  ]
+}
+```


### PR DESCRIPTION
I added a description of our event schema to the docs. We already have it in the comments from the generator and it is available on the [Open Civic Data site](http://docs.opencivicdata.org/en/latest/data/event.html), but I thought it made sense to have it in our docs for ease of access.

I also added some words about the dev process and opening a pull request. It's a start, and I imagine we'll continue to develop that content over time.