### PR TITLE
added more to the docs

### DIFF
--- a/docs/contribute-a-spider.md
+++ b/docs/contribute-a-spider.md
@@ -33,6 +33,15 @@ Created /Users/eads/projects/documenters-aggregator/documenters_aggregator/spide
 Created /Users/eads/projects/documenters-aggregator/tests/test_cha.py
 ```
 
+If you would also like to download some pages for local testing, run:
+
+```
+invoke genspider cha www.thecha.org -s=http://www.thecha.org/events/property_damage_prevention_and_clean-u-9-6-2017,http://www.thecha.org/events/property_management_business_basic-9-13-2017
+```
+
+This will download the two sites passed to the `-s` parameter and save them as html files in `tests/files`.
+
+
 ## Test crawling
 
 You now have a spider named `cha`. To run it (admittedly, not much will happen until you start editing the scraper), run:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,3 +23,28 @@ pip install -r requirements.txt
 ```
 
 If using a fork, replace `City-Bureau` above with your Github username.
+
+### If not using `virtualenv-wrapper`
+`virtualenv-wrapper` gives some useful terminal commands for working with virtual environments. If you aren't using it, you just need to know which files to source for to run the commands.
+
+Set-up:
+If using a fork, replace `City-Bureau` below with your Github username.
+
+```bash
+git clone git@github.com:City-Bureau/documenters-aggregator.git
+cd documenters-aggregator
+virtualenv -p python3 documenters-aggregator
+pip install -r requirements.txt
+```
+
+The third line above will create a folder for your virtual environment called `documenters-aggregator`. (So, there will be a parent and a child folder called `documenters-aggregator`.) The child folder has already been added to the .gitignore. To turn on the virtual environment (assuming you're in the parent `documenters-aggregator` folder):
+
+```bash
+source documenters-aggregator/bin/activate
+```
+
+To turn off the virtual environment:
+
+```bash
+deactivate
+```


### PR DESCRIPTION
- using the `-s` flag with `genspider` to download html files for testing
- setup without virtualenvwrapper (maybe I'm the only one who does this? I like it as a reference since I delete my local repo from time to time.)