### PR TITLE
Added default session value to _gen_html function

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -113,7 +113,7 @@ def _fetch_url(url, attempt=1, session=requests.Session()):
             return _fetch_url(url, attempt + 1)
 
 
-def _gen_html(name, start_urls, session):
+def _gen_html(name, start_urls, session=requests.Session()):
     """
     urls should not end in /
     """


### PR DESCRIPTION
Without this patch, the `genspider` function recommended by the documentation on creating a new spider will fail when it reaches line 58 and tries to run `_gen_html` without a session argument.

The error looks like this:

```python
Traceback (most recent call last):
  File "/home/palewire/.virtualenvs/documenters-aggregator/bin/invoke", line 11, in <module>
    sys.exit(program.run())
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/invoke/program.py", line 294, in run
    self.execute()
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/invoke/program.py", line 409, in execute
    executor.execute(*self.tasks)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/invoke/tasks.py", line 109, in __call__
    result = self.body(*args, **kwargs)
  File "/home/palewire/Code/documenters-aggregator/tasks.py", line 58, in genspider
    _gen_html(name, start_urls)
TypeError: _gen_html() missing 1 required positional argument: 'session'
```