### PR TITLE
Add pipelines import to fix scrapy bug

### DIFF
--- a/documenters_aggregator/pipelines/__init__.py
+++ b/documenters_aggregator/pipelines/__init__.py
@@ -1,6 +1,12 @@
+from .airtable import AirtablePipline
+from .geocoder import GeocoderPipeline
 from .logging import DocumentersAggregatorLoggingPipeline
+from .sqlalchemy import DocumentersAggregatorSQLAlchemyPipeline
 
 
 __all__ = (
     'DocumentersAggregatorLoggingPipeline',
+    'AirtablePipeline',
+    'GeocoderPipeline',
+    'DocumentersAggregatorSQLAlchemyPipeline'
 )

--- a/documenters_aggregator/pipelines/__init__.py
+++ b/documenters_aggregator/pipelines/__init__.py
@@ -1,0 +1,6 @@
+from .logging import DocumentersAggregatorLoggingPipeline
+
+
+__all__ = (
+    'DocumentersAggregatorLoggingPipeline',
+)


### PR DESCRIPTION
The scrapy command is currently failing because the settings are failing to import the logging pipeline from a nested file. I've corrected that problem by introducing an import to the file's parent module that will line up with the path provided in the settings.

Here's the bug I saw that sent me down this route

```python
$ scrapy crawl accc
no pupa_settings on path, using defaults
2017-10-14 13:47:18 [scrapy.utils.log] INFO: Scrapy 1.4.0 started (bot: documenters_aggregator)
2017-10-14 13:47:18 [scrapy.utils.log] INFO: Overridden settings: {'NEWSPIDER_MODULE': 'documenters_aggregator.spiders', 'CLOSESPIDER_ERRORCOUNT': 5, 'COOKIES_ENABLED': False, 'COMMANDS_MODULE': 'documenters_aggregator.commands', 'USER_AGENT': 'Documenters Aggregator [development mode]. Learn more and say hello at https://city-bureau.gitbooks.io/documenters-event-aggregator/', 'BOT_NAME': 'documenters_aggregator', 'SPIDER_MODULES': ['documenters_aggregator.spiders']}
2017-10-14 13:47:18 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats']
2017-10-14 13:47:18 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'documenters_aggregator.middlewares.DocumentersAggregatorRobotsTxtMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2017-10-14 13:47:18 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
Unhandled error in Deferred:
2017-10-14 13:47:18 [twisted] CRITICAL: Unhandled error in Deferred:

2017-10-14 13:47:18 [twisted] CRITICAL: 
Traceback (most recent call last):
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/twisted/internet/defer.py", line 1386, in _inlineCallbacks
    result = g.send(result)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/crawler.py", line 77, in crawl
    self.engine = self._create_engine()
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/crawler.py", line 102, in _create_engine
    return ExecutionEngine(self, lambda _: self.stop())
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/core/engine.py", line 70, in __init__
    self.scraper = Scraper(crawler)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/core/scraper.py", line 71, in __init__
    self.itemproc = itemproc_cls.from_crawler(crawler)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/middleware.py", line 58, in from_crawler
    return cls.from_settings(crawler.settings, crawler)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/middleware.py", line 34, in from_settings
    mwcls = load_object(clspath)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/utils/misc.py", line 44, in load_object
    mod = import_module(module)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/palewire/Code/documenters-aggregator/documenters_aggregator/pipelines/__init__.py", line 1, in <module>
    from logging import DocumentersAggregatorLoggingPipeline
ImportError: cannot import name 'DocumentersAggregatorLoggingPipeline'
Traceback (most recent call last):
  File "/home/palewire/.virtualenvs/documenters-aggregator/bin/scrapy", line 11, in <module>
    sys.exit(execute())
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/cmdline.py", line 149, in execute
    _run_print_help(parser, _run_command, cmd, args, opts)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/cmdline.py", line 89, in _run_print_help
    func(*a, **kw)
  File "/home/palewire/.virtualenvs/documenters-aggregator/lib/python3.5/site-packages/scrapy/cmdline.py", line 156, in _run_command
    cmd.run(args, opts)
  File "/home/palewire/Code/documenters-aggregator/documenters_aggregator/commands/crawl.py", line 14, in run
    crawler = list(self.crawler_process.crawlers)[0]
IndexError: list index out of range
```