### PR TITLE
Spider: PBCC

### DIFF
--- a/documenters_aggregator/spiders/pbcc.py
+++ b/documenters_aggregator/spiders/pbcc.py
@@ -115,18 +115,29 @@ class PbccSpider(scrapy.Spider):
         Parse or generate location. Url, latitutde and longitude are all
         optional and may be more trouble than they're worth to collect.
 
-        TODO: Location details are inconsistent across event types, addresses
-        are mixed up with names and neither are reliably in the same place.
-        Could make manual exceptions for board meetings, or go to sub-page
+        All board meetings and special board meetings are required to be
+        held at the same location, so hard-coding that here with Mapzen
+        Search coordinates included. Otherwise location information is too
+        inconsistent for a reliable format.
         """
-        return {
-            'url': None,
-            'name': None,
-            'coordinates': {
-                'latitude': None,
-                'longitude': None,
-            },
-        }
+        if 'Board Meeting' in self._parse_classification(item):
+            return {
+                'url': 'https://thedaleycenter.com',
+                'name': 'Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street',
+                'coordinates': {
+                    'latitude': 41.884089,
+                    'longitude': -87.630191,
+                },
+            }
+        else:
+            return {
+                'url': None,
+                'name': None,
+                'coordinates': {
+                    'latitude': None,
+                    'longitude': None,
+                },
+            }
 
     def _parse_all_day(self, item):
         """
@@ -156,11 +167,14 @@ class PbccSpider(scrapy.Spider):
         """
         Parse or generate event name.
 
-        Other than the page-long info on AFBs, there isn't much of a description for
-        events outside of the classification and name, so returning None. Could be
-        implemented later for AFBs
+        Returning None for events that are not AFBs, otherwise
+        return a description with the detail link included
         """
-        return None
+        if self._parse_classification(item) == 'Advertisement for Bids':
+            detail_url = self._parse_sources(item)[0]['url']
+            return 'Details on advertisement for bids at: {}'.format(detail_url)
+        else:
+            return None
 
     def _parse_start(self, item, cal_date):
         """

--- a/documenters_aggregator/spiders/pbcc.py
+++ b/documenters_aggregator/spiders/pbcc.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+All spiders should yield data shaped according to the Open Civic Data
+specification (http://docs.opencivicdata.org/en/latest/data/event.html).
+"""
+import re
+import pytz
+import scrapy
+
+from datetime import date, datetime, timedelta
+
+
+class PbccSpider(scrapy.Spider):
+    name = 'pbcc'
+    long_name = 'Public Building Commission of Chicago'
+    allowed_domains = ['www.pbcchicago.com']
+    base_url = 'http://www.pbcchicago.com/content/about/calendar.asp'
+    calendar_date = datetime.now()
+    start_urls = ['{}?myDate={}'.format(
+        base_url, calendar_date.strftime('%m/%d/%Y')
+    )]
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` a dict that follows the `Open Civic Data
+        event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`_.
+
+        Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
+        needs.
+        """
+        for cal_day in response.css('td.calday2'):
+            cal_number = cal_day.xpath("./div[contains(@class, 'calnumber')]/text()").extract_first()
+            if not cal_number:
+                continue
+            cal_date = date(self.calendar_date.year, self.calendar_date.month, int(cal_number))
+            for item in cal_day.xpath("./div[not(contains(@class, 'calnumber'))]"):
+                # Ignore holidays added to calendar
+                if item.css('a b::text').extract_first().strip() != 'Holiday':
+                    yield {
+                        '_type': 'event',
+                        'id': self._parse_id(item),
+                        'name': self._parse_name(item, cal_date),
+                        'description': self._parse_description(item),
+                        'classification': self._parse_classification(item),
+                        'start_time': self._parse_start(item, cal_date),
+                        'end_time': None,
+                        'all_day': self._parse_all_day(item),
+                        'status': self._parse_status(item),
+                        'location': self._parse_location(item),
+                        'sources': self._parse_sources(item)
+                    }
+
+        # Add 30 days to the current date, stop if more than 180 days (~6 months) ahead
+        self.calendar_date += timedelta(days=30)
+        if (self.calendar_date - datetime.now()).days <= 180:
+            yield self._parse_next(response)
+
+    def _parse_next(self, response):
+        """
+        Get next page. You must add logic to `next_url` and
+        return a scrapy request.
+
+        The parse method updates the calendar_date property,
+        so create a query param from that.
+        """
+        next_url = '{}?myDate={}'.format(
+            self.base_url,
+            self.calendar_date.strftime('%m/%d/%Y')
+        )
+        return scrapy.Request(next_url, callback=self.parse)
+
+    def _parse_id(self, item):
+        """
+        Calulate ID. ID must be unique within the data source being scraped.
+
+        All links for PBCC appear to include eID or BID_ID, so raise an error
+        if not found rather than creating a slug.
+        """
+        event_link = item.css('a::attr(href)').extract_first()
+        if '?eID=' in event_link:
+            id_suffix = event_link.split('?eID=')[-1]
+        elif '?BID_ID=' in event_link:
+            id_suffix = event_link.split('?BID_ID=')[-1]
+        else:
+            raise ValueError('ID is required and not present in eID or BID_ID params')
+        return 'PBCC{}'.format(id_suffix)
+
+    def _parse_classification(self, item):
+        """
+        Parse or generate classification (e.g. town hall).
+
+        PBCC has relatively helpful classifications, expanding the AFB acronym.
+        """
+        classification = item.css('a b::text').extract_first().strip()
+        if classification == 'AFB':
+            return 'Advertisement for Bids'
+        else:
+            return classification
+
+    def _parse_status(self, item):
+        """
+        Parse or generate status of meeting. Can be one of:
+
+        * cancelled
+        * tentative
+        * confirmed
+        * passed
+
+        By default, return "tentative"
+        """
+        return 'tentative'
+
+    def _parse_location(self, item):
+        """
+        Parse or generate location. Url, latitutde and longitude are all
+        optional and may be more trouble than they're worth to collect.
+
+        TODO: Location details are inconsistent across event types, addresses
+        are mixed up with names and neither are reliably in the same place.
+        Could make manual exceptions for board meetings, or go to sub-page
+        """
+        return {
+            'url': None,
+            'name': None,
+            'coordinates': {
+                'latitude': None,
+                'longitude': None,
+            },
+        }
+
+    def _parse_all_day(self, item):
+        """
+        Parse or generate all-day status. Defaults to false.
+
+        Returns True if _parse_start_time is None
+        """
+        return self._parse_start_time(item) is None
+
+    def _parse_name(self, item, cal_date):
+        """
+        Parse or generate event name.
+        """
+        name_str = ''.join(item.xpath('./text()').extract()).rstrip().strip()
+        # Return without the beginning and end parentheses, additional spaces
+        # inside of them removed as well
+        clean_name_str = name_str[1:-1].strip()
+        if clean_name_str:
+            return '{} - {}'.format(self._parse_classification(item), clean_name_str)
+        else:
+            return '{} {}'.format(
+                self._parse_classification(item),
+                cal_date.strftime('%m/%d/%Y')
+            )
+
+    def _parse_description(self, item):
+        """
+        Parse or generate event name.
+
+        Other than the page-long info on AFBs, there isn't much of a description for
+        events outside of the classification and name, so returning None. Could be
+        implemented later for AFBs
+        """
+        return None
+
+    def _parse_start(self, item, cal_date):
+        """
+        Parse start date and time.
+
+        Returns the date at midnight if no time provided.
+        """
+        start_time = self._parse_start_time(item)
+        if start_time:
+            start_datetime = datetime.combine(cal_date, start_time)
+        else:
+            start_datetime = datetime.combine(cal_date, datetime.min.time())
+        tz = pytz.timezone('America/Chicago')
+        return tz.localize(start_datetime).isoformat()
+
+    def _parse_start_time(self, item):
+        """
+        Returns a datetime.time object if found in regex search, otherwise none
+
+        Element structure is inconsistent, so search full text.
+        """
+        item_text = ''.join(item.xpath('.//text()').extract())
+        time_str = re.search(r'\d{1,2}:\d{2}(AM|PM)', item_text)
+        if not time_str:
+            return None
+        else:
+            return datetime.strptime(time_str.group(0), '%I:%M%p').time()
+
+    def _parse_sources(self, item):
+        """
+        Parse source from base URL and event link
+        """
+        return [{
+            'url': 'http://www.pbcchicago.com' + item.css('a::attr(href)').extract_first()
+        }]

--- a/tests/files/pbcc.html
+++ b/tests/files/pbcc.html
@@ -1,0 +1,1469 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+	
+
+<title>Public Building Commission of Chicago | PBC Calendar</title>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-81730424-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
+
+
+	<link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
+	
+	<link rel="stylesheet" type="text/css" href="/css/base.css" media="all" />
+	<link rel="stylesheet" type="text/css" href="/css/print.css" media="print" />
+
+	<script type="text/JavaScript">
+	<!--
+		function printit(){  
+		if (window.print) {
+			window.print() ;  
+		} else {
+			var WebBrowser = '<OBJECT ID="WebBrowser1" WIDTH=0 HEIGHT=0 CLASSID="CLSID:8856F961-340A-11D0-A96B-00C04FD705A2"></OBJECT>';
+		document.body.insertAdjacentHTML('beforeEnd', WebBrowser);
+			WebBrowser1.ExecWB(6, 2);
+		}
+		}
+		var win=null;
+		function NewWindow(mypage,myname,w,h,scroll,pos){
+		if(pos=="random"){LeftPosition=(screen.width)?Math.floor(Math.random()*(screen.width-w)):100;TopPosition=(screen.height)?Math.floor(Math.random()*((screen.height-h)-75)):100;}
+		if(pos=="center"){LeftPosition=(screen.width)?(screen.width-w)/2:100;TopPosition=(screen.height)?(screen.height-h)/2:100;}
+		else if((pos!="center" && pos!="random") || pos==null){LeftPosition=0;TopPosition=20}
+		settings='width='+w+',height='+h+',top='+TopPosition+',left='+LeftPosition+',scrollbars='+scroll+',location=no,directories=no,status=no,menubar=no,toolbar=no,resizable=yes';
+		win=window.open(mypage,myname,settings);}
+
+		function dontgo() {} 
+
+		function gotomenu(menu) {            
+			if (menu != "") {                    
+				self.location=menu; 
+			}
+		 }
+	-->
+	</script>
+
+</head>
+
+
+
+<body>
+
+<div id="container">
+	<div id="header">
+		
+			<h1><a href="/"><img src="/images/nav/logo.gif" alt="Public Building Commission of Chicago" width="281" height="91" /></a></h1>
+			
+		
+		<h2><img src="/images/banners/logan_library.jpg" width="563" height="91" alt="Logan Square Branch Library" /></h2>
+
+	</div>
+		
+	
+		
+	<div id="navBar">
+		<ul id="mainNav">
+			
+		<li><a href="/">Home</a></li>
+	
+		<li class="active"><a href="/content/about/">About The PBC</a></li>
+	
+		<li><a href="/content/projects/">PBC Projects</a></li>
+	
+		<li><a href="/content/working/">Doing Business With The PBC</a></li>
+	
+		<li><a href="/content/contact/">Contact The PBC</a></li>
+	
+		</ul>
+		
+		<div id="search">
+			<form action="http://www.pbcchicago.com/content/search/default.asp" id="cse-search-box">
+			<input type="hidden" name="cx" value="007739507344007805884:ix9hqnpryno" />
+			<input type="hidden" name="cof" value="FORID:11" />
+			<input type="hidden" name="ie" value="UTF-8" />
+			<ul>
+				<li><input class="input" type="text" name="q" /></li>
+				<li><input class="button" type="submit" name="sa" value="Search" /></li>
+			</ul>
+			</form>
+			<script type="text/javascript" src="http://www.google.com/coop/cse/brand?form=cse-search-box&lang=en"></script>
+		</div>
+		
+		<div class="clear"></div>
+	</div>
+
+	
+		<div id="content">
+	
+
+		<div id="secondary">
+			<ul id="subNav">
+				
+			<li class="naHeader">
+		
+		<a href="/content/about/default.asp">About The PBC</a>
+		
+		
+	</li>
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/rahm_emanuel.asp">PBC Chairman</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/comissioners.asp">Board of Commissioners</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/carina_sanchez.asp">PBC Executive Director</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/mission_vision.asp">Mission and Vision</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/annual_reports.asp">Annual Reports</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/financial_reports.asp">Financial Reports</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/staff_reports.asp">Staff Reports</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/monthly_reports.asp">Monthly Reports</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/other_reports.asp">Other Reports</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/press_releases.asp">Press Releases</a>
+		
+		
+	</li>
+	
+
+
+	<li style="border:none;">&nbsp;</li>
+
+			<li class="aHeader">
+		
+		<a href="/content/about/calendar.asp">Agendas, Minutes & Notices</a>
+		
+		
+	</li>
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/calendar_types.asp?tID=2">PBC Board</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/calendar_types.asp?tID=3">Audit Committee</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/calendar_types.asp?tID=4">Administrative Operations</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/public_comments.asp">Public Comments</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/calendar_types.asp?tID=10">Community Meetings</a>
+		
+		
+	</li>
+	
+
+
+	<li style="border:none;">&nbsp;</li>
+
+			<li class="naHeader">
+		PBC Board Actions	
+		
+	</li>
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=GC">General Contractors Named</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=AR">Architects Named</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=DB">Design-Builder Named</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=PS">Professional Service Contracts</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=CO">Change Orders</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=CA">Contract Amendments</a>
+		
+		
+	</li>
+	
+
+
+			<li class="naLink">
+		
+		<a href="/content/about/boardaction_view.asp?ACT_ID=OA">Other Actions</a>
+		
+		
+	</li>
+	
+
+
+	<li style="border:none;">&nbsp;</li>
+
+			<li class="naHeader">
+		
+		<a href="/content/about/sister_agencies.asp">Sister Agencies</a>
+		
+		
+	</li>
+
+
+	<li><a href="http://www.cityofchicago.org/" target="_blank">City of Chicago</a></li>
+
+	<li><a href="http://www.cps.edu/" target="_blank">Chicago Public Schools</a></li>
+
+	<li><a href="http://www.chipublib.org/" target="_blank">Chicago Public Library</a></li>
+
+	<li><a href="http://www.chicagoparkdistrict.com/" target="_blank">Chicago Park District</a></li>
+
+	<li><a href="http://www.ccc.edu/" target="_blank">City Colleges of Chicago</a></li>
+
+	<li><a href="http://www.cookcountyil.gov/" target="_blank">Cook County</a></li>
+
+	<li><a href="http://www.fpdcc.com/" target="_blank">Forest Preserve District</a></li>
+
+	<li><a href="http://www.transitchicago.com/" target="_blank">Chicago Transit Authority</a></li>
+
+	<li><a href="http://www.thecha.org/" target="_blank">Chicago Housing Authority</a></li>
+
+	<li><a href="http://www.mwrd.org/" target="_blank">Metropolitan Water Reclamation District</a></li>
+
+	<li><a href="http://www.mpea.com/" target="_blank">Metropolitan Pier and Exposition Authority</a></li>
+
+			</ul>
+		
+		</div>
+	
+		<div id="main">
+	
+	
+
+    <div id="breadcrumb">
+		<a href="/">Home</a> / <a href="/content/about/">About the PBC</a> / PBC Calendar
+	</div>
+
+	<h1>PBC Calendar</h1>
+	
+	
+    <div id="bbox">
+		<div id="title">CALENDAR</div>
+		<div id="contentArea">
+	    	<div>
+	    		<table>
+				<tr>
+				<th style="text-align:left;"><a href="/content/about/calendar.asp?myDate=9/1/2017" class="h3">&lt; PREV</a></th>
+				<th style="text-align:center; font-weight:bold;">October&nbsp;2017</th>
+				<th style="text-align:right;"><a href="/content/about/calendar.asp?myDate=11/1/2017" class="h3">NEXT &gt;</a></th>
+				</tr>
+				</table>
+			</div>
+			
+			<div>
+				<table>
+				<tr>
+				<td class="calday">Sunday</td>
+				<td class="calday">Monday</td>
+				<td class="calday">Tuesday</td>
+				<td class="calday">Wednesday</td>
+				<td class="calday">Thursday</td>
+				<td class="calday">Friday</td>
+				<td class="calday">Saturday</td>	
+				</tr>
+				
+				<tr style="height:100px;">
+						
+						</tr>
+						<tr style="height:100px;">
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">1</div>
+						
+						
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">2</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2166"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=1992"><b>Board Meeting</b></a><br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											2:30PM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_995_file.pdf">Agenda </a><br />
+													
+														<a target="_blank" href="/upload_events/DOC_997_file.pdf">Summary</a><br />
+													
+														<a target="_blank" href="/upload_events/DOC_998_file.pdf">Presentation</a><br />
+													
+												</div>
+											
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">3</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2167"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">4</div>
+						
+						
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">5</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2169"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
+										
+											(Read Dunning - Site Preparation )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2073"><b>Daley Plaza</b></a><br />
+										
+											(Farmers Market)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											7:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">6</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2170"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
+										
+											(Read Dunning - Site Preparation )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2164"><b>Community Hiring</b></a><br />
+										
+											(South Loop Elementary School Community Hiring Event)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_986_file.pdf">Hiring Event Flyer</a><br />
+													
+												</div>
+											
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2095"><b>Daley Plaza</b></a><br />
+										
+											(Food Truck Fests)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">7</div>
+						
+						
+
+
+					</td>
+							
+						</tr>
+						<tr style="height:100px;">
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">8</div>
+						
+						
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">9</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2171"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2042"><b>Holiday</b></a><br />
+										
+											(Columbus Day)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											8:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">10</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2172"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">11</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2173"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">12</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2174"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2074"><b>Daley Plaza</b></a><br />
+										
+											(Farmers Market)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											7:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2165"><b>Community Hiring</b></a><br />
+										
+											(South Loop Elementary School Hiring Event)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_987_file.pdf">Hiring Event Flyer</a><br />
+													
+												</div>
+											
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayold">
+							
+					
+					
+					<div class="calnumber">13</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2175"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2191"><b>Community Hiring</b></a><br />
+										
+											(Ebinger Community Hiring Event)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_999_file.pdf">Ebinger Community Hiring Event Flyer</a><br />
+													
+												</div>
+											
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2096"><b>Daley Plaza</b></a><br />
+										
+											(Food Truck Fests)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="caldayactive">
+							
+					
+					
+					<div class="calnumber">14</div>
+						
+						
+
+
+					</td>
+							
+						</tr>
+						<tr style="height:100px;">
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">15</div>
+						
+						
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">16</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2176"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">17</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2177"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">18</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2178"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=503"><b>AFB</b></a><br />
+										
+											(<br/>Ebinger Elementary School Annex )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=503"><b>AFB</b></a><br />
+										
+											(<br/>Ebinger Elementary School Annex )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:30AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">19</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2179"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=504"><b>AFB</b></a><br />
+										
+											(<br/>Mt. Greenwood Elementary School Annex II  )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=504"><b>AFB</b></a><br />
+										
+											(<br/>Mt. Greenwood Elementary School Annex II  )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:30AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2075"><b>Daley Plaza</b></a><br />
+										
+											(Farmers Market)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											7:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2192"><b>Board Meeting</b></a><br />
+										
+											(Special Board Meeting)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											2:30PM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_1000_file.pdf">Notice</a><br />
+													
+												</div>
+											
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">20</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2180"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2097"><b>Daley Plaza</b></a><br />
+										
+											(Food Truck Fests)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">21</div>
+						
+						
+
+
+					</td>
+							
+						</tr>
+						<tr style="height:100px;">
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">22</div>
+						
+						
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">23</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2181"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">24</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2182"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=501"><b>AFB</b></a><br />
+										
+											(Lake View High School Renovation Rebid 4015 N. Ashland Avenue )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2189"><b>Community Hiring</b></a><br />
+										
+											(Community Hiring Event - Sheridan Math & Science Academy Annex)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_993_file.pdf">Sheridan Math & Science Academy Annex Hiring Event Flyer</a><br />
+													
+												</div>
+											
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">25</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2183"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2098"><b>Daley Plaza</b></a><br />
+										
+											(Food Truck Fests)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">26</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2184"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
+										
+											(Read Dunning - Site Preparation )<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											11:00AM
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2076"><b>Daley Plaza</b></a><br />
+										
+											(Farmers Market)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											7:00AM
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">27</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2185"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">28</div>
+						
+						
+
+
+					</td>
+							
+						</tr>
+						<tr style="height:100px;">
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">29</div>
+						
+						
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">30</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2186"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2190"><b>Community Hiring</b></a><br />
+										
+											(Community Hiring Event - Sheridan Math & Science Academy Annex)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											10:00AM
+										</div>
+										
+										
+												<div style="padding:0 0 5px 0;">
+												
+														<a target="_blank" href="/upload_events/DOC_994_file.pdf">Sheridan Math & Science Academy Annex Hiring Event Flyer</a><br />
+													
+												</div>
+											
+									</div>
+								
+
+
+					</td>
+					
+								<td class="calday2">
+							
+					
+					
+					<div class="calnumber">31</div>
+						
+						
+									<div style="text-align:center;">
+										
+											<a href="/content/about/calendar_detail.asp?eID=2187"><b>Daley Plaza</b></a><br />
+										
+											(Italian Exhibit)<br />
+										
+										
+										<div style="padding:3px 0 5px 0;">
+											
+										</div>
+										
+										
+									</div>
+								
+
+
+					</td>
+					
+				</tr>
+				</table>
+			</div>
+		</div>
+	</div>
+
+	
+	
+	<div id="acrobat"><a style="border-bottom:0;" href="http://www.adobe.com/products/acrobat/readstep2.html"><img src="/images/pics/get_adobe_reader.gif" width="112" height="33" alt="Get Acrobat Reader" /></a></div>
+
+			</div>
+		</div>
+		<div class="clear"></div>
+	</div>
+	
+	
+		<div id="share">
+			<a href="#" onclick="printit()" class="print">Print This Page</a>
+		</div>
+	
+
+	<div id="footer">
+		<div>Copyright &copy; 2017 Public Building Commission of Chicago. All Rights Reserved. <a href="/content/contact/legal_notice.asp">Legal Notice</a>.</div>
+		<div>The PBC logo is a trademark of the Public Building Commission of Chicago.</div>
+	</div>
+
+	</body>
+	</html>

--- a/tests/test_pbcc.py
+++ b/tests/test_pbcc.py
@@ -17,9 +17,12 @@ def test_afb_name():
     assert parsed_items[3]['name'] == 'Advertisement for Bids - Ebinger Elementary School Annex'
 
 
-@pytest.mark.parametrize('item', parsed_items)
-def test_description(item):
-    assert item['description'] is None
+def test_description():
+    assert parsed_items[0]['description'] is None
+
+
+def test_afb_description():
+    assert parsed_items[3]['description'] == 'Details on advertisement for bids at: http://www.pbcchicago.com/content/working/opening_display.asp?BID_ID=503'
 
 
 def test_start_time():
@@ -60,14 +63,24 @@ def test_status(item):
     assert item['status'] == 'tentative'
 
 
-@pytest.mark.parametrize('item', parsed_items)
-def test_location(item):
-    assert item['location'] == {
+def test_location():
+    assert parsed_items[0]['location'] == {
         'url': None,
         'name': None,
         'coordinates': {
             'latitude': None,
             'longitude': None,
+        },
+    }
+
+
+def test_board_meeting_location():
+    assert parsed_items[9]['location'] == {
+        'url': 'https://thedaleycenter.com',
+        'name': 'Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street',
+        'coordinates': {
+            'latitude': 41.884089,
+            'longitude': -87.630191,
         },
     }
 

--- a/tests/test_pbcc.py
+++ b/tests/test_pbcc.py
@@ -1,0 +1,81 @@
+import pytest
+
+from tests.utils import file_response
+from documenters_aggregator.spiders.pbcc import PbccSpider
+
+
+test_response = file_response('files/pbcc.html')
+spider = PbccSpider()
+parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
+
+
+def test_name():
+    assert parsed_items[0]['name'] == 'Daley Plaza - Italian Exhibit'
+
+
+def test_afb_name():
+    assert parsed_items[3]['name'] == 'Advertisement for Bids - Ebinger Elementary School Annex'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_description(item):
+    assert item['description'] is None
+
+
+def test_start_time():
+    assert parsed_items[0]['start_time'] == '2017-10-16T00:00:00-05:00'
+
+
+def test_start_time_with_hours():
+    assert parsed_items[3]['start_time'] == '2017-10-18T10:00:00-05:00'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_end_time(item):
+    assert item['end_time'] is None
+
+
+def test_id():
+    assert parsed_items[0]['id'] == 'PBCC2176'
+
+
+def test_all_day():
+    assert parsed_items[0]['all_day'] is True
+
+
+def test_non_all_day():
+    assert parsed_items[3]['all_day'] is False
+
+
+def test_classification():
+    assert parsed_items[0]['classification'] == 'Daley Plaza'
+
+
+def test_afb_classification():
+    assert parsed_items[3]['classification'] == 'Advertisement for Bids'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_status(item):
+    assert item['status'] == 'tentative'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_location(item):
+    assert item['location'] == {
+        'url': None,
+        'name': None,
+        'coordinates': {
+            'latitude': None,
+            'longitude': None,
+        },
+    }
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test__type(item):
+    assert parsed_items[0]['_type'] == 'event'
+
+
+def test_source():
+    assert parsed_items[0]['sources'][0]['url'] == 'http://www.pbcchicago.com/content/about/calendar_detail.asp?eID=2176'


### PR DESCRIPTION
Closes #71. This is ready for review, but I wanted to flag a couple things I wasn't sure about because  they seemed different than most of the other scrapers.

* I used the few PBCC event types for `classification`, but I could also see those getting moved to `name` alone
* The location information is all over the place in terms of structure and text content, so I left it off since it has the URL included
* I used the `all_day` field events at Daley Plaza without a start time, but not sure if those should just be listed as starting at midnight
* Most events had no description, but the advertisements for bids had full pages ([one example](http://www.pbcchicago.com/content/working/opening_display.asp?BID_ID=502)). Instead of trying to pick which part of the page to include I left `description` blank across the board
* Locally this is dependent on the changes in PR #148, but that could just be my environment