### PR TITLE
Use Flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ documenters_aggregator/caps.py
 # legistar cache
 _cache/
 
+# src dir from git commit packages in requirements.txt
+src/
+
 # deployment
 deploy/*.sh
 deploy/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ decorator==4.1.2
 dj-database-url==0.3.0
 Django==1.11.5
 docutils==0.14
+flake8==3.4.1
 geocoder==1.30.1
 hyperlink==17.3.0
 icalendar==3.11.7
@@ -36,7 +37,6 @@ lxml==4.0.0
 MarkupSafe==1.0
 opencivicdata==2.0.0
 parsel==1.2.0
-pep8==1.7.0
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.14
@@ -48,7 +48,6 @@ pyasn1==0.2.3
 pyasn1-modules==0.0.9
 pycparser==2.18
 PyDispatcher==2.0.5
-pyflakes==1.5.0
 pygeocodio==0.5.0
 Pygments==2.2.0
 pyOpenSSL==17.2.0

--- a/tasks.py
+++ b/tasks.py
@@ -25,6 +25,7 @@ def quote_list(the_list):
     """Jinja helper to quote list items"""
     return ["'%s'" % element for element in the_list]
 
+
 # Jinja env
 env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
 env.filters["quote_list"] = quote_list
@@ -63,8 +64,7 @@ def runtests(ctx):
     Runs pytest, pyflakes, and pep8.
     """
     run('pytest -s', pty=pty_available)
-    run('pyflakes .', pty=pty_available)
-    run('pep8 --ignore E265,E266,E501 .', pty=pty_available)
+    run('flake8 --ignore E265,E266,E501 --exclude src', pty=pty_available)
 
 
 def _make_classname(name):


### PR DESCRIPTION
Was seeing an issue with our linters parsing a `src` directory that I think arose from these changes: 1fd9c7a. This PR is to add [Flake8](http://flake8.pycqa.org/), which has PEP 8 and pyflakes linters built in, while also allowing us to ignore directories we don't need to lint.