### PR TITLE
Convert PBCC coordinates to string

### DIFF
--- a/documenters_aggregator/spiders/pbcc.py
+++ b/documenters_aggregator/spiders/pbcc.py
@@ -125,8 +125,8 @@ class PbccSpider(scrapy.Spider):
                 'url': 'https://thedaleycenter.com',
                 'name': 'Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street',
                 'coordinates': {
-                    'latitude': 41.884089,
-                    'longitude': -87.630191,
+                    'latitude': '41.884089',
+                    'longitude': '-87.630191',
                 },
             }
         else:

--- a/tests/test_pbcc.py
+++ b/tests/test_pbcc.py
@@ -79,8 +79,8 @@ def test_board_meeting_location():
         'url': 'https://thedaleycenter.com',
         'name': 'Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street',
         'coordinates': {
-            'latitude': 41.884089,
-            'longitude': -87.630191,
+            'latitude': '41.884089',
+            'longitude': '-87.630191',
         },
     }
 


### PR DESCRIPTION
Should fix #166, but not completely sure. Looks like I missed the part of `event-schema.md` that says coordinates should be a string. If there are any tests I can add for Airtable let me know