### PR TITLE
Fix PBCC tests

### DIFF
--- a/tests/test_pbcc.py
+++ b/tests/test_pbcc.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 
 from tests.utils import file_response
 from documenters_aggregator.spiders.pbcc import PbccSpider
@@ -6,6 +7,8 @@ from documenters_aggregator.spiders.pbcc import PbccSpider
 
 test_response = file_response('files/pbcc.html')
 spider = PbccSpider()
+# Setting spider date to time test files were generated
+spider.calendar_date = datetime(2017, 10, 15)
 parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
 
 


### PR DESCRIPTION
Fixes the error with the PBCC scraper tests pointed out in #171. The starting date is set in the scraper with `datetime.now()`, which works when it's run normally, but caused an error for the sample data generated in October because it tried to create November 31 based on the HTML file. Manually setting it to that time now so the tests pass