### PR TITLE
Add CTA board spider

### DIFF
--- a/documenters_aggregator/spiders/chi_transit.py
+++ b/documenters_aggregator/spiders/chi_transit.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""
+All spiders should yield data shaped according to the Open Civic Data
+specification (http://docs.opencivicdata.org/en/latest/data/event.html).
+"""
+import re
+import scrapy
+
+from datetime import datetime
+from pytz import timezone
+from slugify import slugify
+
+
+class ChiTransitSpider(scrapy.Spider):
+    name = 'chi_transit'
+    long_name = 'Chicago Transit Authority'
+    allowed_domains = ['www.transitchicago.com']
+    base_url = 'http://www.transitchicago.com'
+    start_urls = ['http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC']
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` a dict that follows the `Open Civic Data
+        event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`_.
+
+        Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
+        needs.
+        """
+        today = datetime.now()
+        for item in response.css('.datatbl tr:not(:first-child)'):
+            item_start = self._parse_start(item)
+            if today < item_start:
+                item_name = self._parse_name(item)
+                item_class = self._parse_classification(item)
+                yield {
+                    '_type': 'event',
+                    'id': self._parse_id(item_start, item_name),
+                    'name': item_name,
+                    'description': self._parse_description(item, item_class),
+                    'classification': item_class,
+                    'start_time': self._format_datetime(item_start),
+                    'end_time': None,
+                    'all_day': False,
+                    'status': self._parse_status(item),
+                    'location': self._parse_location(item),
+                }
+
+    def _parse_id(self, start_time, name):
+        """
+        We use the start time to generate an ID since there is no publically
+        exposed meeting ID.
+        """
+        return slugify(start_time.strftime('%Y-%m-%d-') + name)
+
+    def _parse_classification(self, item):
+        """
+        Parse or generate classification, CTA uses one of three consistently
+        """
+        return item.css('td:nth-child(2)::text').extract_first()
+
+    def _parse_status(self, item):
+        """
+        Parse or generate status of meeting. Can be one of:
+
+        * cancelled
+        * tentative
+        * confirmed
+        * passed
+
+        By default, return "tentative"
+        """
+        return 'tentative'
+
+    def _parse_location(self, item):
+        """
+        Parse or generate location. Url, latitude and longitude are all
+        optional and may be more trouble than they're worth to collect.
+        """
+        location_str = item.css('td:nth-child(4)::text').extract_first()
+        # Always 537 W Lake, so handle that if provided (but allow for change)
+        if re.match(r'567 (W.|W|West) Lake.*', location_str):
+            return {
+                'url': self.base_url,
+                'name': '567 West Lake Street, 2nd Floor, Boardroom, Chicago, IL',
+                'coordinates': {
+                    'latitude': 41.88528,
+                    'longitude': -87.64235,
+                },
+            }
+        else:
+            return {
+                'url': None,
+                'name': location_str,
+                'coordinates': {
+                    'latitude': None,
+                    'longitude': None
+                },
+            }
+
+    def _parse_name(self, item):
+        """
+        Parse or generate event name.
+        """
+        return item.css('td:nth-child(3)::text').extract_first()
+
+    def _parse_description(self, item, classification):
+        """
+        Combine classification with any links present.
+        """
+        description = classification
+        link_items = item.css('td:last-child a')
+        if len(link_items):
+            description += ' - '
+        for link in link_items:
+            description += ' {}: {}{}'.format(
+                link.xpath('./text()').extract_first(),
+                self.base_url,
+                link.xpath('./@href').extract_first()
+            )
+
+        return description
+
+    def _parse_start(self, item):
+        """
+        Parse start date and time.
+        """
+        date_el_text = item.css('td:first-child').extract_first()
+        date_text = date_el_text[4:-5]
+        date_str, time_str = date_text.split('<br>')
+        # A.M. and AM formats are used inconsistently, remove periods
+        time_str = time_str.replace('.', '')
+        if re.match(r'\d{1,2}:\d{2} (AM|PM)', time_str):
+            return datetime.strptime(date_str + time_str, '%m/%d/%Y%I:%M %p')
+        # "Immediately after" specific meeting used frequently, just returning midnight
+        else:
+            return datetime.strptime(date_str, '%m/%d/%Y')
+
+    def _format_datetime(self, time):
+        """
+        Format datetime as timezone-aware,
+        ISO-formatted string.
+        """
+        tz = timezone('America/Chicago')
+        return tz.localize(time).isoformat()

--- a/tests/files/chi_transit.html
+++ b/tests/files/chi_transit.html
@@ -1,0 +1,1313 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<title id="ctl00_PageTitle">Meetings, Agendas and Minutes | Chicago Transit Authority</title>
+<meta name="keywords" content="cta, chicago transit board, meetings, committee, finance, audit, budget, strategic planning, legislative matters, ethics committee, citizens advisory board" />
+<meta name="description" content="The Chicago Transit Authority transit board meets monthly at the CTA main offices. Here we offer meeting dates, agenda, minutes from past meetings. Committee meetings are posted here as well." />
+
+<meta property="og:title" content="Meetings, Agendas and Minutes | Chicago Transit Authority" /><meta property="og:type" content="website" /><meta property="og:url" content="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC" /><meta property="og:description" content="The Chicago Transit Authority transit board meets monthly at the CTA main offices. Here we offer meeting dates, agenda, minutes from past meetings. Committee meetings are posted here as well." /><meta property="og:site_name" content="Transit Chicago" />
+
+<script src="/includes/functions.js" type="text/javascript"></script>
+<link rel="stylesheet" href="/includes/style.css?v=3" type="text/css" />
+<link rel="stylesheet" href="/includes/menu.css?v=1" type="text/css" />
+<script type="text/javascript" src="/includes/swfobject.js"></script>
+<script type="text/javascript" src="/includes/datepicker.js"></script>
+<script type="text/javascript" src="/includes/jquery.js"></script>
+<script type="text/javascript" src="/includes/jquery.jcarousel.js"></script>
+<script type="text/javascript" src="/includes/externallinks.js"></script>
+<script type="text/javascript" src="/includes/superfish.js"></script>
+<script type="text/javascript" src="/includes/jquery-functions.js?v=2"></script>
+<script type="text/javascript" src="/includes/ttdata.aspx"></script>
+<script type="text/javascript" src="/includes/ttcore.js"></script>
+
+
+
+</head>
+<body class="mainbody">
+ 
+ <form name="aspnetForm" method="post" action="/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC" id="aspnetForm">
+<div>
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUENTM4MQ9kFgJmD2QWAmYPZBYCAhIPZBYGAgYPZBYCZg9kFgICAQ8WAh4HVmlzaWJsZWhkAgwPZBYEZg9kFgICAg8WAh8AaGQCAg9kFgICAQ9kFgJmD2QWAmYPZBYUAgEPEA8WBh4NRGF0YVRleHRGaWVsZAUEWWVhch4ORGF0YVZhbHVlRmllbGQFBFllYXIeC18hRGF0YUJvdW5kZ2QQFQoHLS1BbGwtLQQyMDA5BDIwMTAEMjAxMQQyMDEyBDIwMTMEMjAxNAQyMDE1BDIwMTYEMjAxNxUKAAQyMDA5BDIwMTAEMjAxMQQyMDEyBDIwMTMEMjAxNAQyMDE1BDIwMTYEMjAxNxQrAwpnZ2dnZ2dnZ2dnZGQCAw8QDxYGHwEFDENhdGVnb3J5TmFtZR8CBQpDYXRlZ29yeUlkHwNnZBAVBActLUFsbC0tFlRyYW5zaXQgQm9hcmQgTWVldGluZ3MgVHJhbnNpdCBCb2FyZCBDb21taXR0ZWUgTWVldGluZ3MMQ1RBIE1lZXRpbmdzFQQAATEBMgEzFCsDBGdnZ2dkZAIFDw9kFgIeBXN0eWxlBSt3aWR0aDo3NXB4OyBoZWlnaHQ6MjRweDsgYm9yZGVyLXN0eWxlOm5vbmU7ZAIHDw8WAh4EVGV4dGVkZAILDw8WBB8FBYkBRGF0ZS9UaW1lPGltZyBzcmM9Ii9pbWFnZXMvZ2xvYmFsL3NvcnQtYXNjLmdpZiIgYWx0PSJTb3J0IEFycm93IiBzdHlsZT0iYm9yZGVyLXN0eWxlOiBub25lOyB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlOyIgYWx0PSIiIHdpZHRoPSIxNCIgLz4eC05hdmlnYXRlVXJsBVFodHRwOi8vd3d3LnRyYW5zaXRjaGljYWdvLmNvbS9hZ2VuZGFtaW51dGUvZGVmYXVsdC5hc3B4P0ZfT3JkZXJCeT1NZWV0aW5nRGF0ZStBU0NkZAIODw8WBB8FBQhDYXRlZ29yeR8GBVJodHRwOi8vd3d3LnRyYW5zaXRjaGljYWdvLmNvbS9hZ2VuZGFtaW51dGUvZGVmYXVsdC5hc3B4P0ZfT3JkZXJCeT1DYXRlZ29yeU5hbWUrQVNDZGQCEQ8PFgQfBQUMTWVldGluZyBOYW1lHwYFUWh0dHA6Ly93d3cudHJhbnNpdGNoaWNhZ28uY29tL2FnZW5kYW1pbnV0ZS9kZWZhdWx0LmFzcHg/Rl9PcmRlckJ5PU1lZXRpbmdOYW1lK0FTQ2RkAhQPDxYEHwUFCExvY2F0aW9uHwYFVWh0dHA6Ly93d3cudHJhbnNpdGNoaWNhZ28uY29tL2FnZW5kYW1pbnV0ZS9kZWZhdWx0LmFzcHg/Rl9PcmRlckJ5PU1lZXRpbmdMb2NhdGlvbitBU0NkZAIXDxYCHgtfIUl0ZW1Db3VudAIHFg5mD2QWBGYPFQUKMTEvMTUvMjAxNwcyOjAwIFBNIFRyYW5zaXQgQm9hcmQgQ29tbWl0dGVlIE1lZXRpbmdzMkNvbW1pdHRlZSBvbiBTdHJhdGVnaWMgUGxhbm5pbmcgJiBTZXJ2aWNlIERlbGl2ZXJ5NTU2NyBXLiBMYWtlIFN0cmVldCwgMm5kIEZsb29yLCBCb2FyZHJvb20sIENoaWNhZ28sIElMZAIBDxYCHwUFngE8c3BhbiBjbGFzcz0iaWNvbnBkZiI+Jm5ic3A7PC9zcGFuPjxhIHRhcmdldD0iX2JsYW5rIiBocmVmPSIvYXNzZXRzXDFcYWdlbmRhc19taW51dGVzXE5vdjIwMTdfLV9Ob3RpY2VfLV9TdHJhdGVnaWNfUGxhbm5pbmdfQ210ZS5wZGYiPk1lZXRpbmcgTm90aWNlPC9hPjxiciAvPmQCAQ9kFgRmDxUFCjExLzE1LzIwMTcySW1tZWRpYXRlbHkgZm9sbG93aW5nIENtdCBTdHJhdGVnaWMgUGxhbm5pbmcgJiBTdnMgVHJhbnNpdCBCb2FyZCBDb21taXR0ZWUgTWVldGluZ3MkQ29tbWl0dGVlIG9uIEZpbmFuY2UsIEF1ZGl0ICYgQnVkZ2V0NTU2NyBXLiBMYWtlIFN0cmVldCwgMm5kIEZsb29yLCBCb2FyZHJvb20sIENoaWNhZ28sIElMZAIBDxYCHwUFigE8c3BhbiBjbGFzcz0iaWNvbnBkZiI+Jm5ic3A7PC9zcGFuPjxhIHRhcmdldD0iX2JsYW5rIiBocmVmPSIvYXNzZXRzXDFcYWdlbmRhc19taW51dGVzXE5vdjIwMTdfLV9Ob3RpY2VfLV9GQUIucGRmIj5NZWV0aW5nIE5vdGljZTwvYT48YnIgLz5kAgIPZBYEZg8VBQoxMS8xNS8yMDE3BzI6MzAgUE0WVHJhbnNpdCBCb2FyZCBNZWV0aW5ncy5SZWd1bGFyIEJvYXJkIE1lZXRpbmcgb2YgQ2hpY2FnbyBUcmFuc2l0IEJvYXJkNTU2NyBXLiBMYWtlIFN0cmVldCwgMm5kIEZsb29yLCBCb2FyZHJvb20sIENoaWNhZ28sIElMZAIBDxYCHwUFkgE8c3BhbiBjbGFzcz0iaWNvbnBkZiI+Jm5ic3A7PC9zcGFuPjxhIHRhcmdldD0iX2JsYW5rIiBocmVmPSIvYXNzZXRzXDFcYWdlbmRhc19taW51dGVzXE5vdjIwMTdfLV9Ob3RpY2VfLV9SZWd1bGFyX0JyZC5wZGYiPk1lZXRpbmcgTm90aWNlPC9hPjxiciAvPmQCAw9kFgRmDxUFCjEwLzIzLzIwMTcHMjowMCBQTQxDVEEgTWVldGluZ3MsRW1wbG95ZWUgUmV0aXJlbWVudCBSZXZpZXcgQ29tbWl0dGVlIE1lZXRpbmcrNTY3IFdlc3QgTGFrZSBTdHJlZXQgLSAybmQgRmxvb3IgQm9hcmQgUm9vbWQCAQ8WAh8FBYICPHNwYW4gY2xhc3M9Imljb25wZGYiPiZuYnNwOzwvc3Bhbj48YSB0YXJnZXQ9Il9ibGFuayIgaHJlZj0iL2Fzc2V0c1wxXGFnZW5kYXNfbWludXRlc1xFUlJfTm90aWNlXzEwMjMxNy5wZGYiPk1lZXRpbmcgTm90aWNlPC9hPjxiciAvPjxzcGFuIGNsYXNzPSJpY29ucGRmIj4mbmJzcDs8L3NwYW4+PGEgdGFyZ2V0PSJfYmxhbmsiIGhyZWY9Ii9hc3NldHNcMVxhZ2VuZGFzX21pbnV0ZXNcRVJSX0FnZW5kYV8xMDIzMTcucGRmIj5BZ2VuZGE8L2E+PGJyIC8+ZAIED2QWBGYPFQUKMTAvMTEvMjAxNwoxMDowMCBBLk0uFlRyYW5zaXQgQm9hcmQgTWVldGluZ3MuUmVndWxhciBCb2FyZCBNZWV0aW5nIG9mIENoaWNhZ28gVHJhbnNpdCBCb2FyZDU1NjcgVy4gTGFrZSBTdHJlZXQsIDJuZCBGbG9vciwgQm9hcmRyb29tLCBDaGljYWdvLCBJTGQCAQ8WAh8FBZwCPHNwYW4gY2xhc3M9Imljb25wZGYiPiZuYnNwOzwvc3Bhbj48YSB0YXJnZXQ9Il9ibGFuayIgaHJlZj0iL2Fzc2V0c1wxXGFnZW5kYXNfbWludXRlc1xPY3QyMDE3Xy1fTm90aWNlXy1fUmVndWxhcl9CcmQucGRmIj5NZWV0aW5nIE5vdGljZTwvYT48YnIgLz48c3BhbiBjbGFzcz0iaWNvbnBkZiI+Jm5ic3A7PC9zcGFuPjxhIHRhcmdldD0iX2JsYW5rIiBocmVmPSIvYXNzZXRzXDFcYWdlbmRhc19taW51dGVzXE9jdDIwMTdfLV9SZWd1bGFyX0JvYXJkX0FnZW5kYS5wZGYiPkFnZW5kYTwvYT48YnIgLz5kAgUPZBYEZg8VBQoxMC8xMS8yMDE3CTk6MDAgQS5NLiBUcmFuc2l0IEJvYXJkIENvbW1pdHRlZSBNZWV0aW5ncyRDb21taXR0ZWUgb24gRmluYW5jZSwgQXVkaXQgJiBCdWRnZXQ1NTY3IFcuIExha2UgU3RyZWV0LCAybmQgRmxvb3IsIEJvYXJkcm9vbSwgQ2hpY2FnbywgSUxkAgEPFgIfBQWOAjxzcGFuIGNsYXNzPSJpY29ucGRmIj4mbmJzcDs8L3NwYW4+PGEgdGFyZ2V0PSJfYmxhbmsiIGhyZWY9Ii9hc3NldHNcMVxhZ2VuZGFzX21pbnV0ZXNcT2N0MjAxN18tX05vdGljZV8tX0ZBQi5wZGYiPk1lZXRpbmcgTm90aWNlPC9hPjxiciAvPjxzcGFuIGNsYXNzPSJpY29ucGRmIj4mbmJzcDs8L3NwYW4+PGEgdGFyZ2V0PSJfYmxhbmsiIGhyZWY9Ii9hc3NldHNcMVxhZ2VuZGFzX21pbnV0ZXNcT2N0MjAxN18tX0ZBQl9XZWJfQWdlbmRhLnBkZiI+QWdlbmRhPC9hPjxiciAvPmQCBg9kFgRmDxUFCjEwLzEwLzIwMTcJMTozMCBQLk0uDENUQSBNZWV0aW5ncx5BREEgQWR2aXNvcnkgQ29tbWl0dGVlIE1lZXRpbmc1NTY3IFcuIExha2UgU3RyZWV0LCAybmQgRmxvb3IsIEJvYXJkcm9vbSwgQ2hpY2FnbywgSUxkAgEPFgIfBQW8AjxzcGFuIGNsYXNzPSJpY29ucGRmIj4mbmJzcDs8L3NwYW4+PGEgdGFyZ2V0PSJfYmxhbmsiIGhyZWY9Ii9hc3NldHNcMVxhZ2VuZGFzX21pbnV0ZXNcQURBX0FkdnNfQ29tbXRfTXRnX19Ob3RpY2VfZm9yX09jdG9iZXJfMTBfMjAxNy5wZGYiPk1lZXRpbmcgTm90aWNlPC9hPjxiciAvPjxzcGFuIGNsYXNzPSJpY29ucGRmIj4mbmJzcDs8L3NwYW4+PGEgdGFyZ2V0PSJfYmxhbmsiIGhyZWY9Ii9hc3NldHNcMVxhZ2VuZGFzX21pbnV0ZXNcQURBX0FkdnNfQ29tbXRfTXRnX0FnZW5kYV9mb3JfVHVlcy1PY3RfMTAtMjAxNy5wZGYiPkFnZW5kYTwvYT48YnIgLz5kAhkPZBYEZg9kFgYCAQ8WAh8FBQhQcmV2aW91c2QCAw8WAh8FBc4DPHNwYW4gY2xhc3M9InJlZHR4dCI+MTwvc3Bhbj4gPGEgaHJlZj0iaHR0cDovL3d3dy50cmFuc2l0Y2hpY2Fnby5jb20vYWdlbmRhbWludXRlL2RlZmF1bHQuYXNweD9GX09yZGVyQnk9TWVldGluZ0RhdGUrREVTQyZhbXA7cGc9MiI+MjwvYT4gPGEgaHJlZj0iaHR0cDovL3d3dy50cmFuc2l0Y2hpY2Fnby5jb20vYWdlbmRhbWludXRlL2RlZmF1bHQuYXNweD9GX09yZGVyQnk9TWVldGluZ0RhdGUrREVTQyZhbXA7cGc9MyI+MzwvYT4gPGEgaHJlZj0iaHR0cDovL3d3dy50cmFuc2l0Y2hpY2Fnby5jb20vYWdlbmRhbWludXRlL2RlZmF1bHQuYXNweD9GX09yZGVyQnk9TWVldGluZ0RhdGUrREVTQyZhbXA7cGc9NCI+NDwvYT4gPGEgaHJlZj0iaHR0cDovL3d3dy50cmFuc2l0Y2hpY2Fnby5jb20vYWdlbmRhbWludXRlL2RlZmF1bHQuYXNweD9GX09yZGVyQnk9TWVldGluZ0RhdGUrREVTQyZhbXA7cGc9NSI+NTwvYT4gZAIFDxYCHwUFbjxhIGhyZWY9Imh0dHA6Ly93d3cudHJhbnNpdGNoaWNhZ28uY29tL2FnZW5kYW1pbnV0ZS9kZWZhdWx0LmFzcHg/Rl9PcmRlckJ5PU1lZXRpbmdEYXRlK0RFU0MmYW1wO3BnPTIiPk5leHQ8L2E+ZAIBDxYCHwUFQjxhIGhyZWY9Ij9GX09yZGVyQnk9TWVldGluZ0RhdGUrREVTQyZhbXA7QWxsPXkiPlZpZXcgQWxsICgzNzkpPC9hPmQCDg9kFgICAQ9kFgJmD2QWBAIXDw8WAh8FBQoxMS8xMC8yMDE3ZGQCHw8PFgIfBQVVaHR0cDovL2VsYi1qcGluc3RhbmNlcy0xNDYzMDI4NTQ3LnVzLWVhc3QtMS5lbGIuYW1hem9uYXdzLmNvbS9jY2czL1hTTFRfVFJJUF9SRVFVRVNUMmRkGAEFHl9fQ29udHJvbHNSZXF1aXJlUG9zdEJhY2tLZXlfXxYKBRFjdGwwMCRjdGwwOCRmZGF0ZQURY3RsMDAkY3RsMDgkZnRpbWUFFWN0bDAwJGN0bDAzJGJ0blNlYXJjaAUdY3RsMDAkQWdlbmRhTWludXRlMSRidG5TZWFyY2gFD2N0bDAwJGN0bDA4JG5vdwURY3RsMDAkY3RsMDgkbGVhdmUFEmN0bDAwJGN0bDA4JGFycml2ZQUXY3RsMDAkY3RsMDgkZmRhdGUkY3RsMDAFEmN0bDAwJGN0bDA4JGltZ0J0bgUVY3RsMDAkY3RsMDgkaW1nUlRBTURWJjdr2mSxvGwUJMG6HF15NxcVGDk=" />
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
+    }
+}
+//]]>
+</script>
+
+
+<script src="/WebResource.axd?d=uLiVyfLFjffXlQAh2b7lzEnuTlSEGSUzdoOEI2uiroydyL42NVK94XStsJTwMnnOcFdznZ826poq4Z2WA-W4W0drvqk1&amp;t=636284453271971599" type="text/javascript"></script>
+
+
+<script src="/ScriptResource.axd?d=1uhTAeh1YxbHWScJFfPX4lzMeZ6ph23Bk0WldYwvXbAXjuFXvBXdRAwsyld-XsDC-MVwpMQB_Ne3MKG9xs3ta2gSw9T9AYkJ2L0HIf1OQnN90mBqbMGnF3W5_juZJjx8yw3McH9V9c4xeEWBZW0k5JMn1Yg1&amp;t=635580335611168044" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=yaL9YAjLKEaCMhjusmDbnP4RA1rOJN6PhuPt5Uu8_0kpOLKykAd5wi9UEMBgZvR9l9inj2Mde9JktaLl_vQ0o38Ls2AWQl62ao7Ynfa64ynAT3dXBd-JEPM2Kmm1NtQ4Zeevm5RldAbLhznOV2POw4At3AQg7Pcfg_OOFm81TXjh13rv0&amp;t=635580335611168044" type="text/javascript"></script>
+<div>
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="3E094B3F" />
+	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEWOwLD6fWcCgLn1YudAwLf9PGxAwLl/7+sCgLN0eapBwKm6NQwAqbo6O0LAqbo/MoCAqbokKcKAqbopJwNAqbouPkEAqbozNUPAqbo4LIHAsqQhN0PAsX/rrMDAsT/rrMDAsf/rrMDAvzk4MMKAt2b+MEIAtib5L4IAqSDmKYKAojL94MMArT2u+IMAs3RvkACmKesxgICvY6uqQoC7e6n2AQCtbCk9wQC7OKsjAECtJS7kw0CjJzLtggC/7Ke5gQC/rKe5gQC/bKe5gQC/LKe5gQC+7Ke5gQC+rKe5gQC+bKe5gQC6LKe5gQC57Ke5gQC/7Le5QQC/7LS5QQC/7LW5QQCj83xpgUClM3xpgUCkM2xpQUCkM2NpQUCkc2xpQUCkc2NpQUCks2xpQUCks2NpQUCk82xpQUCk82NpQUClM2xpQUClM2NpQUC5fWopAYCyvWopAYC0OfuuAsC1uzKuwpE7830B4NNXrDyNjl0WRa1+qJxbg==" />
+</div><script type="text/javascript">
+//<![CDATA[
+Sys.WebForms.PageRequestManager._initialize('ctl00$AjaxManager', document.getElementById('aspnetForm'));
+Sys.WebForms.PageRequestManager.getInstance()._updateControls(['tctl00$AgendaMinute1$upAgenda'], ['ctl00$AgendaMinute1$btnSearch'], [], 90);
+//]]>
+</script>
+
+
+
+  <div class="skip"><a href="#maincontent">Skip to main content</a>&nbsp;|&nbsp;<a href="/sitemap.aspx">Skip to site map</a></div>
+  <div class="contentbody">
+		<!-- start core -->
+	<div class="bdywrpr">
+
+	<!-- start header -->
+		<div class="hdrwrpr">
+			
+<div class="hdrcta">
+    <a href="/">
+        <img src="/images/global/hdr-cta.gif" style="width: 415px; height: 70px; border-style: none;"
+            alt="CTA - Chicago Transit Authority" /></a><br />
+</div>
+<div class="hdrlnks">
+    <a href="/accessibility"><img src="/assets/1/icons/12pxISA.png" alt="" align="absmiddle" style="margin-right: 1px;" />Accessibility</a><span class="pipe">|</span><a href="/mobile/">Mobile</a><span class="pipe">|</span><a href="/faq/help.aspx">Help</a><span class="pipe">|</span><a href="/contact/default.aspx">Contact</a><span class="pipe">|</span><a href="/sitemap.aspx">Site Map</a>
+</div>
+<div id="ctl00_ctl03_pnlSearchHeader" class="hdrsrchbx" onkeypress="javascript:return WebForm_FireDefaultButton(event, 'ctl00_ctl03_btnSearch')">
+	
+    <div class="hdrsrchinput">
+        <input name="ctl00$ctl03$txtSearch" type="text" value="search" maxlength="30" id="ctl00_ctl03_txtSearch" title="Keyword search" class="srchbx" onfocus="this.value=''" /><br />
+        <input type="image" name="ctl00$ctl03$btnSearch" id="ctl00_ctl03_btnSearch" class="srchbtn" src="/images/global/btn-srch-go.gif" alt="Go" style="border-width:0px;" /><br />
+    </div>
+
+</div>
+
+<!-- start menu bar -->
+<div class="hdrtnav">
+    <div class="hdrtnavtl">
+    </div>
+    <div class="hdrtnavtr">
+    </div>
+    <div class="mainNav">
+        <ul class="sf-menu sf-js-enabled">
+            <li><a href="http://www.transitchicago.com/travel_information/default.aspx">Travel Info</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/brochures.aspx">Brochures</a>
+</li><li><a href="http://ctabustracker.com/bustime/home.jsp" target="_blank">CTA Bus Tracker</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.ctabustracker.com">On the Web</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/bustrackertext.aspx">By Text (SMS) Message</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/traintracker/default.aspx">CTA Train Tracker</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/traintracker/">Pick a stop</a>
+</li><li><a href="http://www.transitchicago.com/traintracker/help.aspx">Help &amp; Notes</a>
+</li><li><a href="http://www.transitchicago.com/surveys/start.aspx?SurveyId=4">Feedback/Survey</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/traintrackertext.aspx">By Text (SMS) Message</a>
+</li><li><a href="http://www.transitchicago.com/traintrackermap/" target="_blank">See trains on a map</a>
+</li><li><a href="http://www.transitchicago.com/traintracker/signupdate.aspx">Train Tracker Widescreen Sign Update</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/alerts/">Customer Alerts</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/travel_information/bus_status.aspx">Bus Alerts</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/accessibility_status.aspx">Elevator/Accessibility Status Alerts</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/railstatus.aspx">'L' Alerts (Trains)</a>
+</li><li><a href="http://www.transitchicago.com/rss/default.aspx">RSS Feeds</a>
+</li><li><a href="http://transitchicago.com/updates">Subscribe to Updates</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/systemalerts.aspx">System Status &amp; Alerts</a>
+</li><li><a href="http://www.transitchicago.com/weekday/">Weekday Service Changes</a>
+</li><li><a href="http://www.transitchicago.com/weekend/">Weekend Service Changes</a>
+</li><li><a href="http://www.transitchicago.com/cubsgamealerts/">Cubs Night Game Alerts Test</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/fares/">Fares</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/fares/">Basic Fare Information</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/reduced.aspx">Reduced Fare &amp; Free Ride Programs</a>
+</li><li><a href="http://www.transitchicago.com/students/">Student Ventra Cards &amp; Student Reduced Fare</a>
+</li><li><a href="http://www.transitchicago.com/schooladmins/">Ventra Info for School Administrators</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/unlimitedridecards.aspx">Unlimited Ride Passes</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/wheretobuy.aspx">Where to Buy Fares</a>
+</li><li><a href="http://www.transitchicago.com/upass/">U-Pass</a>
+</li><li><a href="http://www.transitchicago.com/transitbenefit/">Transit Benefit Program (Pre-Tax Fare)</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/military.aspx">Military Service Pass</a>
+</li><li><a href="http://www.rtachicago.com" target="_blank">Seniors Ride Free (RTA)</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/maps/">Maps</a>
+</li><li><a href="http://www.transitchicago.com/schedules/">Schedules</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/travel_information/schedules.aspx">Routes &amp; Schedules</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/bus_schedules.aspx">List of Bus Schedules</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/allrailschedules.aspx">List of Train Schedules</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/updates/">Subscribe to CTA Updates</a>
+</li><li><a href="http://www.transitchicago.com/planatrip/">Trip Planners</a>
+</li><li><a href="http://www.transitchicago.com/apps/default.aspx">Transit Apps</a>
+</li></ul>
+
+</li><li><a href="http://www.transitchicago.com/riding_cta/default.aspx">How to Ride</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/service_overview.aspx">About CTA Service (Overview)</a>
+</li><li><a href="http://www.transitchicago.com/accessibility">Accessibility</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/accessibility">Accessibility (Overview)</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/accessibleservices.aspx">List of Accessible CTA Services</a>
+</li><li><a href="http://www.transitchicago.com/accessibility/features.aspx">Accessibility Features</a>
+</li><li><a href="http://www.transitchicago.com/accessibility/faq.aspx">Accessibility FAQ</a>
+</li><li><a href="http://www.transitchicago.com/accessibility/whatsnew.aspx">What's New in Accessibility</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/adaac.aspx">ADA Advisory Committee</a>
+</li><li><a href="http://www.transitchicago.com/accessibility/asap.aspx">All Stations Accessibility Program (ASAP)</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/airports/">Airport Transit: Getting to O'Hare &amp; Midway</a>
+</li><li><a href="http://www.transitchicago.com/bikeandride/">Bike &amp; Ride</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/bike_and_ride.aspx">Bike &amp; Ride Overview</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/bikebus.aspx">On the bus</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/biketrain.aspx">On the train</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/brochures/">Brochures</a>
+</li><li><a href="http://www.transitchicago.com/howto/">How-to Guides</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/default.aspx">How-To Guides</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/findingyourway.aspx">Plan a Trip / Find Your Way</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/regionalconnections.aspx">Regional Transit Connections</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/bustrackertext.aspx">Bus Tracker by Text (SMS)</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/traintrackertext.aspx">Train Tracker by Text (SMS)</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/buyingfare.aspx">Buying Fares / Tickets</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/payingyourfare.aspx">Paying a Fare</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/ridingthebus.aspx">Riding the Bus</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/ridingthetrain.aspx">Riding the Train</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/bikebus.aspx">Bikes on Buses</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/how_to_guides/biketrain.aspx">Bikes on Trains</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/riding_cta/lostandfound.aspx">Lost &amp; Found</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/systemguide/default.aspx">Route &amp; System Guide</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/systemguide/default.aspx">System Guide</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/systemguide/buses.aspx">Bus Routes</a>
+</li><li><a href="http://www.transitchicago.com/redline/">Red Line</a>
+</li><li><a href="http://www.transitchicago.com/blueline/">Blue Line</a>
+</li><li><a href="http://www.transitchicago.com/brownline/">Brown Line</a>
+</li><li><a href="http://www.transitchicago.com/greenline/">Green Line</a>
+</li><li><a href="http://www.transitchicago.com/orangeline/">Orange Line</a>
+</li><li><a href="http://www.transitchicago.com/purpleline/">Purple Line</a>
+</li><li><a href="http://www.transitchicago.com/pinkline/">Pink Line</a>
+</li><li><a href="http://www.transitchicago.com/yellowline/">Yellow Line</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/parking/">Park &amp; Ride</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/policies.aspx">Policies &amp; Practices</a>
+</li><li><a href="http://www.transitchicago.com/rules/">Rules of Conduct</a>
+</li><li><a href="http://www.transitchicago.com/safety/default.aspx">Safety</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/safety/default.aspx">Safety</a>
+</li><li><a href="http://www.transitchicago.com/safety/ee.aspx">Elevator &amp; Escalator Safety Tips</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/security/">Security</a>
+</li><li><a href="http://www.transitchicago.com/visitors/">Visitor Info / Destinations</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/riding_cta/visitor_information.aspx">Visitor Information</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/airports.aspx">Getting to/from the Airport</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/popdest/sports.aspx">Chicago Sports Venues</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/related_links.aspx">Related Links</a>
+</li><li><a href="http://www.transitchicago.com/business/photopolicy.aspx">Photo Policy</a>
+</li><li><a href="http://www.transitchicago.com/riding_cta/populardestinations.aspx">Popular Destinations</a>
+</li></ul>
+</li>
+</ul>
+
+</li><li><a href="http://www.transitchicago.com/news_initiatives/default.aspx">News &amp; Initiatives</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/speakup/">Anti-Harassment Campaign</a>
+</li><li><a href="http://www.transitchicago.com/chartertrain/">Charter a Train</a>
+</li><li><a href="http://www.transitchicago.com/communityconnection/">Community Connection</a>
+</li><li><a href="http://www.transitchicago.com/courtesy/">Courtesy</a>
+</li><li><a href="http://www.transitchicago.com/developers/default.aspx">Developer Center</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/developers">Developer Center</a>
+</li><li><a href="http://www.transitchicago.com/developers/traintracker.aspx">CTA Train Tracker API</a>
+</li><li><a href="http://www.transitchicago.com/developers/bustracker.aspx">CTA Bus Tracker API</a>
+</li><li><a href="http://www.transitchicago.com/developers/alerts.aspx">Customer Alerts API</a>
+</li><li><a href="http://www.transitchicago.com/developers/gtfs.aspx">Scheduled Service Data (GTFS)</a>
+</li><li><a href="http://www.transitchicago.com/developers/furtherreading.aspx">Further Reading</a>
+</li><li><a href="http://www.transitchicago.com/developers/diydisplay.aspx">DIY Transit Info Display</a>
+</li><li><a href="http://www.transitchicago.com/developers/branding.aspx">CTA Trademarks &amp; You</a>
+</li><li><a href="http://www.transitchicago.com/developers/terms.aspx">Developer License Agreement &amp; Terms of Use</a>
+</li><li><a href="http://www.transitchicago.com/apps">Apps</a>
+</li><li><a href="http://www.transitchicago.com/data">Open Data</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/goinggreen/default.aspx">Going Green</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/goinggreen/default.aspx">Green Initiatives</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/lowemissions.aspx">Sustainable Transportation</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/vehicles.aspx">Clean Vehicles</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/multimode.aspx">Multimodal Connections</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/facilities.aspx">Efficient Facilities</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/materials.aspx">Resource Recycling</a>
+</li><li><a href="http://www.transitchicago.com/goinggreen/grants.aspx">Green Grants</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/heritagefleet/">Heritage Fleet</a>
+</li><li><a href="http://www.transitchicago.com/data/">Open Data</a>
+</li><li><a href="http://www.transitchicago.com/performance/">Performance</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://transitchicago.com/performance">Performance Metrics</a>
+</li><li><a href="http://www.transitchicago.com/ridership/">Ridership Reports</a>
+</li><li><a href="http://www.transitchicago.com/sze">Slow Zone Elimination &amp; Maps</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/whenthingsgowrong.aspx">When Things Go Wrong (Why Delays Happen)</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/news_initiatives/planning/default.aspx">Planning &amp; Expansion</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/news_initiatives/planning/altanalysis.aspx">Alternatives Analysis Studies (and archives)</a>
+</li><li><a href="http://www.transitchicago.com/westernashlandbrt/">Ashland Bus Rapid Transit (BRT)</a>
+</li><li><a href="http://www.transitchicago.com/blueweststudy/">Blue Line Forest Pk. Br. Feas./Vision Study</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/planning/circle.aspx">Circle Line Alternatives Analysis</a>
+</li><li><a href="http://www.transitchicago.com/jefferyproject/">Jeffery Jump</a>
+</li><li><a href="http://www.transitchicago.com/orangeeis/default.aspx">Orange Line Extension</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/planning/pacenorthshore.aspx">Pace/CTA North Shore Coordination Plan</a>
+</li><li><a href="http://www.transitchicago.com/redahead/">Red Ahead</a>
+</li><li><a href="http://www.transitchicago.com/rpmproject/">Red &amp; Purple Modernization Project</a>
+</li><li><a href="http://www.transitchicago.com/redeis/">Red Line Extension</a>
+</li><li><a href="http://www.transitchicago.com/yelloweis/default.aspx">Yellow Line Extension</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/news/default.aspx?Month=&amp;Year=&amp;Category=2">Press Releases</a>
+</li><li><a href="http://www.transitchicago.com/art/">Public Art</a>
+</li><li><a href="http://www.transitchicago.com/news/reports.aspx">Reports &amp; Notices</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/projects/default.aspx">System Improvement Projects</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/news_initiatives/projects/default.aspx">Overview (All Current &amp; Recent Projects)</a>
+</li><li><a href="http://www.transitchicago.com/31pilot/">#31 31st Pilot</a>
+</li><li><a href="http://www.transitchicago.com/95thTerminal/">95th/Dan Ryan Station Improvements</a>
+</li><li><a href="http://www.transitchicago.com/ashlandbrt/">Ashland Bus Rapid Transit (BRT)</a>
+</li><li><a href="http://www.transitchicago.com/ashlandwesternx/">Ashland &amp; Western Bus Improvements</a>
+</li><li><a href="http://www.transitchicago.com/sheltersigns/">Bus Tracker Shelter Displays</a>
+</li><li><a href="http://www.transitchicago.com/electricbus/">Electric Buses</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/projects/elevesc.aspx">Elevator &amp; Escalator Upgrades</a>
+</li><li><a href="http://www.transitchicago.com/garfieldgateway/">Garfield Gateway</a>
+</li><li><a href="http://www.transitchicago.com/greenwest/">Green Line West Track Renewal</a>
+</li><li><a href="http://www.transitchicago.com/imd/">Illinois Medical District Renovation</a>
+</li><li><a href="http://www.transitchicago.com/looplink/">Loop Link</a>
+</li><li><a href="http://www.transitchicago.com/looplinkprepaid/">Loop Link Pre-paid Fare Payment Pilot</a>
+</li><li><a href="http://www.transitchicago.com/quincy/">Quincy Station Improvements</a>
+</li><li><a href="http://www.transitchicago.com/prepaidboarding/">Prepaid Bus Fare Payment</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/planning/yourred/default.aspx">Red Ahead</a>
+</li><li><a href="http://www.transitchicago.com/redsouthart/">Red Line South Art</a>
+</li><li><a href="http://www.transitchicago.com/sze/">Slow Zone Elimination</a>
+</li><li><a href="http://www.transitchicago.com/wilson/">Wilson Station Reconstruction Project</a>
+</li><li><a href="http://www.transitchicago.com/yournewblue/">Your New Blue</a>
+</li><li><a href="http://www.transitchicago.com/washingtonwabash/">Washington/Wabash Station</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/videos/">Videos</a>
+</li><li><a href="http://www.transitchicago.com/winterprep/">Winter Preparedness</a>
+</li></ul>
+
+</li><li><a href="http://www.transitchicago.com/fares_gifts/default.aspx">Shop Online</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/fares">Fare Information</a>
+</li><li><a href="http://faremedia.chicago-card.com/">Buy Farecards &amp; Passes Online</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/wheretobuy.aspx">How to Buy Fare, In Person</a>
+</li><li><a href="http://www.ctagifts.com">Gifts (ctagifts.com)</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/retailmap.aspx">Map of Where to Buy Fares</a>
+</li><li><a href="http://www.transitchicago.com/travel_information/fares/vendingmachines.aspx">Vending Machine Locations</a>
+</li><li><a href="http://ventrachicago.com">Ventra (Get new card, load value and passes)</a>
+</li></ul>
+
+</li><li><a href="http://www.transitchicago.com/business/default.aspx">Business</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/adjacentconstruction/">Adjacent Construction</a>
+</li><li><a href="http://www.transitchicago.com/advertising/">Advertising on CTA</a>
+</li><li><a href="http://www.transitchicago.com/news_initiatives/btforbusiness.aspx">Bus &amp; Train Tracker for Business</a>
+</li><li><a href="http://www.transitchicago.com/buyingplan/">Buying Plan</a>
+</li><li><a href="http://www.transitchicago.com/careers/default.aspx">Careers</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/careers">Careers</a>
+</li><li><a href="http://www.transitchicago.com/business/internships/legalext.aspx">Legal Intern Program</a>
+</li><li><a href="http://www.transitchicago.com/internships/">Internships</a>
+</li><li><a href="http://www.transitchicago.com/business/internships/hscoop.aspx">High School Co-Op Program</a>
+</li><li><a href="http://www.transitchicago.com/secondchance/">Second Chance Program</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/partnership/">Corporate Partnership</a>
+</li><li><a href="http://www.transitchicago.com/developers/default.aspx">Developers</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/dbe.aspx">Disadvantaged Business Enterprise (DBE)</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/dbe/">Overview &amp; Certification Info</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/dbeinfo/compliance.aspx">Compliance</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/dbeinfo/dbeassist.aspx">Assistance Agencies</a>
+</li><li><a href="http://cta.dbesystem.com">Vendor/DBE Registration</a>
+</li><li><a href="http://www.transitchicago.com/sbe/">Small Business Program</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/employees/default.aspx">Employee Portal</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://transitchicago.com/employees">Employee Portal (Home)</a>
+</li><li><a href="http://www.transitchicago.com/hrbenefits/">HR Benefits</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/eeo/">Equal Employment Opportunity (EEO)</a>
+</li><li><a href="http://www.transitchicago.com/business/financebudget.aspx">Finance &amp; Budget</a>
+</li><li><a href="http://www.transitchicago.com/foia/">Freedom of Information (FOIA)</a>
+</li><li><a href="http://www.transitchicago.com/business/filmingandphoto.aspx">Filming &amp; Photography</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/film.aspx">Filming &amp; Photography</a>
+</li><li><a href="http://www.transitchicago.com/business/photopolicy.aspx">Photo &amp; Video Policy</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/procurement/">Procurement Information</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/procurmt.aspx">General Information</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/procurement_process.aspx">Procurement Process</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/contract_opportunities.aspx">Contract Opportunities</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/sbops.aspx">Small Business Contract Opportunities</a>
+</li><li><a href="http://cta.dbesystem.com">Vendor / DBE Registration</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/download_forms.aspx">Download Forms</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/events.aspx">Calendar/Events</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/ssdp.aspx">Sole Source &amp; Disadvantageous Procurements</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/regulation_and_polices.aspx">Regulations &amp; Policies</a>
+</li><li><a href="http://www.transitchicago.com/asset.aspx?AssetId=2359">Suspensions / Debarments (pdf)</a>
+</li><li><a href="http://vcsearch.transitchicago.com/">Vendor, Contract &amp; Payment Search</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/faq.aspx">Procurement FAQ</a>
+</li><li><a href="http://www.transitchicago.com/business/procurement_information/contacts.aspx">Department Contacts</a>
+</li></ul>
+</li>
+<li><a href="http://www.ctarealestate.com/">Real Estate Leasing &amp; Sales</a>
+</li></ul>
+
+</li><li><a href="http://www.transitchicago.com/about/default.aspx">About Us</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/about/overview.aspx">About the CTA</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/about/overview.aspx">About Us</a>
+</li><li><a href="http://www.transitchicago.com/historicalcalendar/">Historical Calendar</a>
+</li><li><a href="http://www.transitchicago.com/about/facts.aspx">Facts at a Glance</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/contact/custserv.aspx">Customer Service</a>
+</li><li><a href="http://transitchicago.com/careers">Careers</a>
+</li><li><a href="http://www.transitchicago.com/contact/default.aspx">Contact Us</a>
+</li><li><a href="http://www.transitchicago.com/board/">Chicago Transit Board &amp; Meetings</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://www.transitchicago.com/about/transit_board_meetings/default.aspx">About Chicago Transit Board Meetings</a>
+</li><li><a href="http://www.transitchicago.com/agendaminute/default.aspx">Meeting Notices, Agendas and Minutes</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/public_comment.aspx">Public Comment Process</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/boardpresentations.aspx">Board Presentations</a>
+</li><li><a href="http://www.transitchicago.com/news/default.aspx?Month=&amp;Year=&amp;Category=4">Reports &amp; Notices</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/ordinances.aspx">Ordinances</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/adaac.aspx">ADA Advisory Committee</a>
+</li><li><a href="http://www.transitchicago.com/boardvideo/">Board Meeting Video</a>
+</li><li><a href="http://www.transitchicago.com/about/transit_board_meetings/resolutions.aspx">Resolutions</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/documents/default.aspx">Documents</a>
+</li><li><a href="http://www.transitchicago.com/employees/default.aspx">Employees</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://transitchicago.com/employees/">Employee Portal (Home)</a>
+</li><li><a href="http://transitchicago.com/hrbenefits">HR Benefits (Health Plan Open Enrollment)</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/about/governance.aspx">Governance &amp; Administration</a>
+</li><li><a href="http://www.transitchicago.com/about/letter.aspx">Letter from the Chairman &amp; President</a>
+</li><li><a href="http://www.transitchicago.com/business/financebudget.aspx">Finance &amp; Budget</a>
+</li><li><a href="http://www.transitchicago.com/business/freedom_of_information.aspx">Freedom of Information (FOIA)</a>
+</li><li><a href="http://transitchicago.com/faq/faq.aspx">Frequently Asked Questions (FAQ)</a>
+</li><li><a href="http://www.transitchicago.com/oeig/">Office of the Executive Inspector General</a>
+</li><li><a href="http://transitchicago.com/performance">Performance</a>
+<ul style="display: none; visibility: hidden; ">
+<li><a href="http://transitchicago.com/performance">Performance Metrics &amp; Reports</a>
+</li><li><a href="http://www.transitchicago.com/sze">Rail Slow Zone Maps</a>
+</li><li><a href="http://transitchicago.com/news_initiatives/ridershipreports.aspx">Ridership Reports</a>
+</li></ul>
+</li>
+<li><a href="http://www.transitchicago.com/news/default.aspx?Month=&amp;Year=&amp;Category=2&amp;about=1">Press Releases</a>
+</li><li><a href="http://www.transitchicago.com/news/default.aspx?Month=&amp;Year=&amp;Category=4">Reports &amp; Notices</a>
+</li><li><a href="http://www.transitchicago.com/social/">Social Media</a>
+</li><li><a href="http://www.transitchicago.com/about/title6.aspx">Title VI Information</a>
+</li></ul>
+
+</li>
+        </ul>
+        <div class="clear">
+            &nbsp;</div>
+    </div>
+</div>
+<!-- end menu bar -->
+
+
+		</div>
+	<!-- end header -->
+
+
+<!-- travel alert -->
+	
+<!-- end travel alert -->
+
+
+
+	<!-- start core -->
+		<div class="corwrpr" style="z-index:0">
+
+		<!-- start sub header -->
+			<div class="subhdrwrpr">
+				
+<div class="breadcrumb">
+    <a href="http://www.transitchicago.com">CTA Home</a><span>&nbsp;:&nbsp;</span><a href="http://www.transitchicago.com/about/default.aspx">About Us</a><span>&nbsp;:&nbsp;</span><a href="http://www.transitchicago.com/about/transit_board_meetings/default.aspx">Chicago Transit Board &amp; Meetings</a><span>&nbsp;:&nbsp;</span><span>Meeting Notices, Agendas and Minutes</span>
+</div>
+    
+<div class="sitetools">
+					<div class="prnteml">
+						<a href="#" onclick="OpenPopup('/emailfriend.aspx?url=/agendaminute/default.aspx%3fF_OrderBy%3dMeetingDate%2bDESC','emailpage', 660, 575, 'yes', 'no'); return false;" class="emaillnk">E-mail</a>
+						<a href="/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;print=y" class="printlnk">Print</a>
+					</div>
+					
+<div class="addthis" style="height: 16px;">
+    <div class="atshare">Share:</div>
+    <a class="addthis_button_facebook"></a>
+    <a class="addthis_button_twitter"></a>
+    <a class="addthis_button_google_plusone"></a>
+    <a class="addthis_button_compact"></a>
+</div>
+<script type="text/javascript">
+    $('.addthis_button_google_plusone').attr('g:plusone:count', 'false');
+    $('.addthis_button_google_plusone').attr('style', 'width:30px');
+</script>
+<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid=transitchicago"></script>
+
+<script type="text/javascript">
+    /* <![CDATA[ */
+    var addthis_config = {
+        data_use_flash:false,
+        username:"Transitchicago",
+        ui_cobrand:"CTA",
+        services_exclude:"print,email"
+    }
+    $(document).ready(function () {
+      addthis.init();
+    });
+
+    /* ]]> */
+</script>
+
+
+</div>
+<div class="clear">&nbsp;</div>
+			</div>
+		<!-- end sub header -->
+
+		<!-- start layout -->
+			<div class="innerwrpr">
+				<div class="col680">
+
+					<a name="maincontent"></a>
+
+				<!-- start print content -->
+		
+<!-- image -->
+	
+	<!-- end image -->
+<h1>Meetings, Agendas and Minutes</h1>
+<p>This page shows information about meetings held by the Chicago Transit Board, committees, and related meetings.</p>
+<h5>See also:</h5>
+<ul>
+    <li><strong>To view presentations made to the Board</strong>, see <a href="/about/transit_board_meetings/boardpresentations.aspx">Board Presentations</a>.&nbsp;For ordinances approved by the Chicago Transit Board, see <a href="/about/transit_board_meetings/ordinances.aspx">Ordinances</a>.</li>
+    <li><strong>To view archival information of meeting notices</strong>, including those&nbsp;about Board Meetings dated before January 1, 2009, see <a href="/news/reports.aspx">Reports&nbsp;&amp;&nbsp;Notices</a>.</li>
+    <li><strong>For more information about Chicago Transit Board meetings </strong>and the annual schedule, see the main <a href="/about/transit_board_meetings/default.aspx">Transit Board Meetings</a> page.</li>
+    <li><strong>To see live video of Chicago Transit Board meetings</strong>, see <a href="/boardvideo">Board Video</a>.</li>
+</ul>
+<div id="ctl00_AgendaMinute1_upAgenda">
+	
+    <!-- round corners box -->
+		<div class="rndbxmod lblue">
+			<div class="tlftcrnr">&nbsp;</div><div class="trtcrnr">&nbsp;</div><div class="clear">&nbsp;</div>
+				<div style="margin:6px 10px;">
+						<div style="float:left; margin-right:10px;">
+						
+							<strong>Year:</strong>
+							<select name="ctl00$AgendaMinute1$F_Year" id="ctl00_AgendaMinute1_F_Year" style="width:85px; vertical-align:middle;">
+		<option selected="selected" value="">--All--</option>
+		<option value="2009">2009</option>
+		<option value="2010">2010</option>
+		<option value="2011">2011</option>
+		<option value="2012">2012</option>
+		<option value="2013">2013</option>
+		<option value="2014">2014</option>
+		<option value="2015">2015</option>
+		<option value="2016">2016</option>
+		<option value="2017">2017</option>
+
+	</select>
+							</div>
+						<div style="float:left; margin-right:10px;">
+							<strong>Category:</strong>
+<select name="ctl00$AgendaMinute1$F_CategoryId" id="ctl00_AgendaMinute1_F_CategoryId" style="vertical-align:middle;">
+		<option selected="selected" value="">--All--</option>
+		<option value="1">Transit Board Meetings</option>
+		<option value="2">Transit Board Committee Meetings</option>
+		<option value="3">CTA Meetings</option>
+
+	</select>
+													</div>
+
+						<div style="float:left; margin-right:15px;">
+						   <input type="image" name="ctl00$AgendaMinute1$btnSearch" id="ctl00_AgendaMinute1_btnSearch" title="Search" src="/images/global/btn-search.gif" alt="Search" style="border-width:0px;width:75px; height:24px; border-style:none;" /><br />
+						</div>
+
+					<div class="clear">&nbsp;</div>
+				</div>
+			<div class="clear">&nbsp;</div><div class="blftcrnr">&nbsp;</div><div class="brtcrnr">&nbsp;</div><div class="clear">&nbsp;</div>
+		</div>
+		<span id="ctl00_AgendaMinute1_lblCategoryDescription"></span>
+	<!-- end round corners box -->
+       <p><span id="ctl00_AgendaMinute1_lblDescription"></span></p>
+	<div style="clear: both;"></div>
+	  <table border="0" cellpadding="0" cellspacing="0" class="datatbl" style="width:100%;" summary="Meeting records table">
+	   <tbody>
+	    <tr>    
+ 	     <th scope="col" width="75px"><a id="ctl00_AgendaMinute1_hlDate" href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+ASC">Date/Time<img src="/images/global/sort-asc.gif" alt="Sort Arrow" style="border-style: none; vertical-align: middle;" alt="" width="14" /></a></th>
+	     <th scope="col"><a id="ctl00_AgendaMinute1_hlCategory" href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=CategoryName+ASC">Category</a></th>
+	     <th scope="col" width="200px"><a id="ctl00_AgendaMinute1_hlName" href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingName+ASC">Meeting Name</a></th>
+	     <th scope="col" width="100px"><a id="ctl00_AgendaMinute1_hlLocation" href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingLocation+ASC">Location</a></th>
+	     <th scope="col">Agenda / Minutes / Other</th>
+	    </tr>	 	
+	
+	  <tr class="alternate">
+	   <td>11/15/2017<br />2:00 PM</td>
+	   <td>Transit Board Committee Meetings</td>
+	   <td>Committee on Strategic Planning & Service Delivery</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Nov2017_-_Notice_-_Strategic_Planning_Cmte.pdf">Meeting Notice</a><br /></td>
+	  </tr>	 
+	 
+	  <tr>
+	   <td>11/15/2017<br />Immediately following Cmt Strategic Planning & Svs</td>
+	   <td>Transit Board Committee Meetings</td>
+	   <td>Committee on Finance, Audit & Budget</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>	   	   
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Nov2017_-_Notice_-_FAB.pdf">Meeting Notice</a><br /></td>
+	  </tr>	 	 
+	 
+	  <tr class="alternate">
+	   <td>11/15/2017<br />2:30 PM</td>
+	   <td>Transit Board Meetings</td>
+	   <td>Regular Board Meeting of Chicago Transit Board</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Nov2017_-_Notice_-_Regular_Brd.pdf">Meeting Notice</a><br /></td>
+	  </tr>	 
+	 
+	  <tr>
+	   <td>10/23/2017<br />2:00 PM</td>
+	   <td>CTA Meetings</td>
+	   <td>Employee Retirement Review Committee Meeting</td>
+	   <td>567 West Lake Street - 2nd Floor Board Room</td>	   	   
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\ERR_Notice_102317.pdf">Meeting Notice</a><br /><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\ERR_Agenda_102317.pdf">Agenda</a><br /></td>
+	  </tr>	 	 
+	 
+	  <tr class="alternate">
+	   <td>10/11/2017<br />10:00 A.M.</td>
+	   <td>Transit Board Meetings</td>
+	   <td>Regular Board Meeting of Chicago Transit Board</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Oct2017_-_Notice_-_Regular_Brd.pdf">Meeting Notice</a><br /><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Oct2017_-_Regular_Board_Agenda.pdf">Agenda</a><br /></td>
+	  </tr>	 
+	 
+	  <tr>
+	   <td>10/11/2017<br />9:00 A.M.</td>
+	   <td>Transit Board Committee Meetings</td>
+	   <td>Committee on Finance, Audit & Budget</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>	   	   
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Oct2017_-_Notice_-_FAB.pdf">Meeting Notice</a><br /><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\Oct2017_-_FAB_Web_Agenda.pdf">Agenda</a><br /></td>
+	  </tr>	 	 
+	 
+	  <tr class="alternate">
+	   <td>10/10/2017<br />1:30 P.M.</td>
+	   <td>CTA Meetings</td>
+	   <td>ADA Advisory Committee Meeting</td>
+	   <td>567 W. Lake Street, 2nd Floor, Boardroom, Chicago, IL</td>
+	   <td class="smaller"><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\ADA_Advs_Commt_Mtg__Notice_for_October_10_2017.pdf">Meeting Notice</a><br /><span class="iconpdf">&nbsp;</span><a target="_blank" href="/assets\1\agendas_minutes\ADA_Advs_Commt_Mtg_Agenda_for_Tues-Oct_10-2017.pdf">Agenda</a><br /></td>
+	  </tr>	 
+	 
+	   <tbody>
+	  </table>
+	 
+	&lt;&nbsp;Previous&nbsp;|&nbsp;<span class="redtxt">1</span> <a href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;pg=2">2</a> <a href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;pg=3">3</a> <a href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;pg=4">4</a> <a href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;pg=5">5</a> &nbsp;|&nbsp;<a href="http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC&amp;pg=2">Next</a>&nbsp;&gt;&nbsp;<a href="?F_OrderBy=MeetingDate+DESC&amp;All=y">View All (379)</a>
+
+    
+</div>
+
+
+
+
+				<!-- end print content -->
+
+
+				</div>
+				<div class="col240">
+					
+  <!-- rider tool box -->
+		<div class="rrmodwrpr">
+			<h3>Quick Links</h3>
+			<div class="rrmodtop">&nbsp;</div>
+			<div class="rrmodbdy">
+				<div class="rrmodtbx notranslate">
+  
+     <a href="/travel_information/schedules.aspx?source_quicklinks=1" id="_5c1b4d8aea17_rptRiderToolRail_ctl01_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_sched.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl01_imgIcon" alt="Schedules" /><br />Schedules</a>
+  
+     <a href="/travel_information/maps/default.aspx?source_quicklinks=1" id="_5c1b4d8aea17_rptRiderToolRail_ctl02_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_maps.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl02_imgIcon" alt="Maps" /><br />Maps</a>
+  
+     <a href="/travel_information/systemalerts.aspx?source_quicklinks=1" id="_5c1b4d8aea17_rptRiderToolRail_ctl03_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_alerts.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl03_imgIcon" alt="Alerts" /><br />Alerts</a>
+  
+     <a href="/tracker/?source_quicklinks=1" id="_5c1b4d8aea17_rptRiderToolRail_ctl04_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_trackers.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl04_imgIcon" alt="Transit Tracker" /><br />Transit Tracker</a>
+  
+     <a href="http://www.ventrachicago.com" id="_5c1b4d8aea17_rptRiderToolRail_ctl05_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_ventra.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl05_imgIcon" alt="Ventra" /><br />Ventra</a>
+  
+     <a href="/travel_information/fares/default.aspx?source_quicklinks=1" id="_5c1b4d8aea17_rptRiderToolRail_ctl06_lnkRailRiderTool"><img src="/assets/1/quick_links_icons/qlicon_fares.png" id="_5c1b4d8aea17_rptRiderToolRail_ctl06_imgIcon" alt="Fare Info" /><br />Fare Info</a>
+  
+<div class="clear">&nbsp;</div>
+				</div>
+			</div>
+			<div class="rrmodbtm">&nbsp;</div>
+		</div>
+	<!-- end rider tool box -->
+  
+
+<script language="javascript" type="text/javascript">
+   
+/* <![CDATA[ */
+    var dtCh = "/";
+    var dteNow = new Date();
+    var minYear = dteNow.getFullYear();
+    var maxYear = minYear + 1;
+
+    function isInteger(s) {
+        var i;
+        for (i = 0; i < s.length; i++) {
+            var c = s.charAt(i);
+            if (((c < "0") || (c > "9"))) return false;
+        }
+        return true;
+    }
+
+    function stripCharsInBag(s, bag) {
+        var i;
+        var returnString = "";
+        for (i = 0; i < s.length; i++) {
+            var c = s.charAt(i);
+            if (bag.indexOf(c) == -1) returnString += c;
+        }
+        return returnString;
+    }
+
+    function daysInFebruary(year) {
+        return (((year % 4 == 0) && ((!(year % 100 == 0)) || (year % 400 == 0))) ? 29 : 28);
+    }
+    
+    function DaysArray(n) {
+        for (var i = 1; i <= n; i++) {
+            this[i] = 31
+            if (i == 4 || i == 6 || i == 9 || i == 11) { this[i] = 30 }
+            if (i == 2) { this[i] = 29 }
+        }
+        return this
+    }
+
+    function isDate(dtStr) {
+        var daysInMonth = DaysArray(12)
+        var pos1 = dtStr.indexOf(dtCh)
+        var pos2 = dtStr.indexOf(dtCh, pos1 + 1)
+        var strMonth = dtStr.substring(0, pos1)
+        var strDay = dtStr.substring(pos1 + 1, pos2)
+        var strYear = dtStr.substring(pos2 + 1)
+        strYr = strYear
+        if (strDay.charAt(0) == "0" && strDay.length > 1) strDay = strDay.substring(1)
+        if (strMonth.charAt(0) == "0" && strMonth.length > 1) strMonth = strMonth.substring(1)
+        for (var i = 1; i <= 3; i++) {
+            if (strYr.charAt(0) == "0" && strYr.length > 1) strYr = strYr.substring(1)
+        }
+        month = parseInt(strMonth)
+        day = parseInt(strDay)
+        year = parseInt(strYr)
+        if (pos1 == -1 || pos2 == -1) {
+            alert("Date is not in a valid format. Enter the date in mm/dd/yyyy format.")
+            return false
+        }
+        if (strMonth.length < 1 || month < 1 || month > 12) {
+            alert("Please enter a valid month.")
+            return false
+        }
+        if (strDay.length < 1 || day < 1 || day > 31 || (month == 2 && day > daysInFebruary(year)) || day > daysInMonth[month]) {
+            alert("Please enter a valid day.")
+            return false
+        }
+        if (strYear.length != 4 || year == 0 || year < minYear || year > maxYear) {
+            alert("Please enter a valid 4 digit year between " + minYear + " and " + maxYear + ".")
+            return false
+        }
+        if (dtStr.indexOf(dtCh, pos2 + 1) != -1 || isInteger(stripCharsInBag(dtStr, dtCh)) == false) {
+            alert("Please enter a valid date.")
+            return false
+        }
+        return true
+    }
+    
+     
+    function submitGoogle() {
+    
+    var now = document.getElementById('ctl00_ctl08_now');        
+    if (!now.checked) {
+    var date = document.getElementById('ctl00_ctl08_fdate_cal');   
+        if (isDate(date.value) == false) {
+                date.focus();
+                return false;
+            }
+        }
+   }
+
+
+    function submitMDV() {
+        var origAddress = $('#ctl00_ctl08_origAddress').val();
+        var destAddress = $('#ctl00_ctl08_destAddress').val();
+        $("#name_origin").val(origAddress);
+        $("#name_destination").val(destAddress);
+        
+        var d = new Date();
+        var itdDateDay = d.getDate();
+        var itdDateMonth = d.getMonth()+1;
+        var itdDateYear = d.getFullYear();
+        var itdTimeHour = d.getHours();
+        var itdTimeMinute = d.getMinutes();
+
+
+        var now = document.getElementById('ctl00_ctl08_now'); 
+
+        if (!now.checked) {
+            var sd = $("input[name*='fdate']").val();
+            var arrsd = sd.split("/");
+            itdDateDay = arrsd[1];
+            itdDateMonth = arrsd[0];
+            itdDateYear = arrsd[2];
+
+            var arrive = document.getElementById('ctl00_ctl08_arrive');
+            if (arrive.checked) {
+                var arriveLeave = document.getElementById('arriveLeave');
+                arriveLeave.value = 'arr'
+            }
+            var leave = document.getElementById('ctl00_ctl08_leave');
+            if (leave.checked) {
+                var arriveLeave = document.getElementById('arriveLeave');
+                arriveLeave.value = 'dep';
+            }
+            $("#itdTripDateTimeDepArr").val(arriveLeave.value);
+
+            itdTimeHour = $("select[id*='ftime_H']").val();
+            itdTimeMinute = $("select[id*='ftime_M']").val();
+            itdTimeAMPM = $("select[id*='ftime_AMPM']").val();
+            
+
+            starttime24hr = convert_to_24h(itdTimeHour + ":" + itdTimeMinute + ":00 " + itdTimeAMPM)
+            arrstarttime24hr = starttime24hr.split(":");
+            itdTimeHour = arrstarttime24hr[0];
+            itdTimeMinute = arrstarttime24hr[1];
+        }
+
+        $("#itdDateDay").val(itdDateDay); 
+        $("#itdDateMonth").val(itdDateMonth); 
+        $("#itdDateYear").val(itdDateYear);
+
+        $("#itdTimeHour").val(itdTimeHour);
+        $("#itdTimeMinute").val(itdTimeMinute);
+
+        $.ajax({
+            type: 'GET',
+            cache: false,
+            url: '/ajax/keywordajax.aspx',
+            dataType: 'json',
+            async: false,
+            data: { origAddress: origAddress, destAddress: destAddress },
+            success: function (result) {
+               
+                $("#name_origin").val(result.origAddress);
+                $("#name_destination").val(result.destAddress);
+
+                document.forms[0].action = $('#ctl00_ctl08_lblLink').html() 
+                document.forms[0].submit();
+
+            }
+        });
+        
+        
+        
+    }
+
+    function convert_to_24h(time_str) {
+        // Convert a string like 10:05:23 PM to 24h format, returns like [22,5,23]
+        var time = time_str.match(/(\d+):(\d+):(\d+) (\w)/);
+        var hours = Number(time[1]);
+        var minutes = Number(time[2]);
+        var seconds = Number(time[3]);
+        var meridian = time[4].toLowerCase();
+
+        if (meridian == 'p' && hours < 12) {
+            hours = hours + 12;
+        }
+        else if (meridian == 'a' && hours == 12) {
+            hours = hours - 12;
+        }
+        return hours+":"+minutes;
+    };
+    
+    function enterPressed(e) {
+        var code;
+        if (!e) var e = window.event;
+        if (e.keyCode) code = e.keyCode;
+        else if (e.which) code = e.which;
+        if(code == 13) {        
+            alert('Please choose a trip planner to get directions from.');
+            return false;
+        }
+    }
+
+    $(document).ready(function() {
+        $("#tpexpanderbtn").click(function(eo) {  
+        $("#tpexpoptions").slideDown(250, function() {
+          $("#tpexpanderarrow").css("backgroundImage", "url(/images/tt_optpanel_rollup.gif)");
+        });
+        $("#tpexpanderbtn").unbind("click").animate({opacity: 0}, 250, "swing", function() {
+          $(this).hide();
+        });
+      });
+    });
+/* ]]> */
+</script>
+
+
+<div id="ctl11_pnlTripPlanner" class="rrmodwrpr" onkeypress="return enterPressed(event);">
+    <div id="ctl00_ctl08_pnlTripPlanner">
+	
+        <h3>
+            <a href="/travel_information/trip_planner.aspx">Plan a trip</a></h3>
+        <div class="rrmodtop">
+            &nbsp;</div>
+        <div class="rrmodbdy">
+            <div class="rrmodcontent">
+                <select name="ampm" id="ampm" style="display: none;">
+                    <option value="am">AM</option>
+                    <option value="pm">PM</option>
+                </select>
+                <input type="hidden" name="ctl00$ctl08$ie" id="ctl00_ctl08_ie" value="UTF8" />
+                <input type="hidden" name="ctl00$ctl08$f" id="ctl00_ctl08_f" value="d" />
+                <input type="hidden" name="ctl00$ctl08$sll" id="ctl00_ctl08_sll" value="41.812267,-87.837067" />
+                <input type="hidden" name="ctl00$ctl08$sspn" id="ctl00_ctl08_sspn" value="0.732868,1.450195" />
+                <input value="false" id="advanced" name="advanced" type="hidden" />
+                <input value="true" id="newTrip" name="newTrip" type="hidden" />
+                <input value="true" id="newRequest" name="newRequest" type="hidden" />
+                <input id="origData" name="origData" type="hidden" />
+                <input id="destData" name="destData" type="hidden" />
+                <input id="origAddress" name="origAddress" type="hidden" />
+                <input id="destAddress" name="destAddress" type="hidden" />
+                <input value="1" id="trip" name="trip" type="hidden" />
+                <input id="train" name="train" value="true" type="hidden" />
+                <input id="bus" name="bus" value="true" type="hidden" />
+                <input id="drive" name="drive" value="false" type="hidden" />
+                <input id="driveToTransit" name="driveToTransit" value="false" type="hidden" />
+                <input id="hour" name="hour" type="hidden" />
+                <input name="ctl00$ctl08$hourNow" type="hidden" id="ctl00_ctl08_hourNow" value="4" />
+                <input id="minute" name="minute" type="hidden" />
+                <input name="ctl00$ctl08$minuteNow" type="hidden" id="ctl00_ctl08_minuteNow" value="05" />
+                <input id="arriveLeave" value="dep" name="arriveLeave" type="hidden" />
+                <input id="ftime" name="ftime" type="hidden" />
+                <input id="travelDate" name="travelDate" type="hidden" />
+                <strong><font size="2px">Start</font></strong> (e.g. O'Hare Airport)<br />
+                <input name="ctl00$ctl08$origAddress" type="text" maxlength="2048" id="ctl00_ctl08_origAddress" title="Address, Intersection or Station" class="ibox" style="width: 210px; margin: 2px 0 0 0;" /><br />
+                <strong><font size="2px">End</font></strong> (e.g. 1 N State St, Chicago, IL)<br />
+                <input name="ctl00$ctl08$destAddress" type="text" maxlength="2048" id="ctl00_ctl08_destAddress" title="Address, Intersection or Station" class="ibox" style="width: 210px; margin: 2px 0 0 0;" /><br />
+                <br />
+                <div style="margin-bottom: 22px;">
+                    <div style="float:left; width: 110px;"><input value="arriveLeave" name="ctl00$ctl08$arriveLeave" type="radio" id="ctl00_ctl08_now" alt="Leave Now" checked="checked" /><strong>Leave Now</strong></div>
+                    <div id="tpexpanderbtn" style="cursor: pointer;float: right;"><div style="float:left;margin-right: 5px;"><strong>More </strong></div><div id="tpexpanderarrow" style="height: 17px;width: 17px; background-image: url(/images/tt_optpanel_expanddown.gif); float:left;">&nbsp;</div></div>        
+                </div>
+                <div class="tripplanwrpr">
+                    <div class="clear">
+                    </div>
+                </div>
+                <div style="display: none; margin-bottom: 20px;" id="tpexpoptions">
+                  <div style="padding-bottom: 10px;">
+                      <input value="dep" name="ctl00$ctl08$arriveLeave" type="radio" id="ctl00_ctl08_leave" alt="Depart" /><strong>Depart
+                      </strong><span class="gray pipe">or</span>
+                      <input value="arr" name="ctl00$ctl08$arriveLeave" type="radio" id="ctl00_ctl08_arrive" alt="Arrive" /><strong>Arrive
+                      </strong>
+                  </div>
+                  <strong>on</strong>
+                  <span id="ctl00_ctl08_fdate" title="Enter the date in mm/dd/yyyy format"><input name="ctl00$ctl08$fdate$cal" type="text" value="11/10/2017" id="ctl00_ctl08_fdate_cal" class="ibox" onclick="popUpCalendar(document.getElementById('ctl00_ctl08_fdate_cal'),document.getElementById('ctl00_ctl08_fdate_cal'), 'mm/dd/yyyy');" alt="DatePicker" style="width:80px;" /><input type="image" name="ctl00$ctl08$fdate$ctl00" src="/images/calendar/picker.gif" alt="Calendar" onclick="popUpCalendar(document.getElementById('ctl00_ctl08_fdate_cal'),document.getElementById('ctl00_ctl08_fdate_cal'), 'mm/dd/yyyy'); return false;" style="border-width:0px;vertical-align:middle;padding-bottom:5px;" /></span>
+                  
+                  <br />
+                  <strong>&nbsp;at&nbsp;</strong><span id="ctl00_ctl08_ftime" title="Select time" class="ibox"><select name="ctl00$ctl08$ftime$H" id="ctl00_ctl08_ftime_H" class="ibox">
+		<option value="1">01</option>
+		<option value="2">02</option>
+		<option value="3">03</option>
+		<option selected="selected" value="4">04</option>
+		<option value="5">05</option>
+		<option value="6">06</option>
+		<option value="7">07</option>
+		<option value="8">08</option>
+		<option value="9">09</option>
+		<option value="10">10</option>
+		<option value="11">11</option>
+		<option value="12">12</option>
+
+	</select>:<select name="ctl00$ctl08$ftime$M" id="ctl00_ctl08_ftime_M" class="ibox">
+		<option value="0">00</option>
+		<option selected="selected" value="5">05</option>
+		<option value="10">10</option>
+		<option value="15">15</option>
+		<option value="20">20</option>
+		<option value="25">25</option>
+		<option value="30">30</option>
+		<option value="35">35</option>
+		<option value="40">40</option>
+		<option value="45">45</option>
+		<option value="50">50</option>
+		<option value="55">55</option>
+
+	</select>&nbsp;<select name="ctl00$ctl08$ftime$AMPM" id="ctl00_ctl08_ftime_AMPM" class="ibox">
+		<option value="AM">AM</option>
+		<option selected="selected" value="PM">PM</option>
+
+	</select></span>
+
+                </div>
+                <b>&nbsp;Get directions with:</b>
+                <div align="center">
+                    <input type="image" name="ctl00$ctl08$imgBtn" id="ctl00_ctl08_imgBtn" title="use Google Maps" src="/images/global/btn_googxit.png" alt="use Google Maps" onclick="javascript:pageTracker._trackPageview('/outgoing/www.google.com/transit');return submitGoogle();" style="border-width:0px;border-style: none;" />&nbsp;
+
+                    <!-- hidden form elements -->
+                    <input type="hidden" name="actn" id="actn" value="entry" />
+                    <input type="hidden" value="false" id="Hidden1" name="advanced" />
+                    <input type="hidden" value="true" id="Hidden2" name="newTrip" />
+                    <input type="hidden" value="true" id="Hidden3" name="newRequest" />
+                    <input type="hidden" id="Hidden4" name="origData" />
+                    <input type="hidden" id="Hidden5" name="destData" />
+                    <input type="hidden" value="1" id="Hidden6" name="trip" />
+                    <input type="hidden" name="mode" id="mode">
+                    <input type="hidden" id="Hidden8" name="hour" />
+                    <input type="hidden" id="Hidden9" name="minute" />
+                    <input type="hidden" id="Hidden10" name="ampm" value="PM" />
+                    <input type="hidden" id="Hidden11" name="travelDate" />
+                    <!-- xiaoni	-->
+                    <input type="hidden" name="language" value="en" />
+                    <input type="hidden" name="itdLPxx_directRequest" value="1" />
+                    <input type="hidden" name="sessionID" value="0" />
+                    <input type="hidden" name="std3_commonMacro" value="trip" />
+                    <input type="hidden" name="type_origin" value="any" />
+                    <input type="hidden" name="type_destination" value="any" />
+                    <input type="hidden" name="tdLPxx_timeFormat" value="12" />
+                    <!-- xiaoni end -->
+
+                    <input type="hidden" value="02" name="itdDateDay" id="itdDateDay" />
+                    <input type="hidden" value="04" name="itdDateMonth" id="itdDateMonth" />
+                    <input type="hidden" value="2016" name="itdDateYear" id="itdDateYear" />
+
+                    <input type="hidden" value="11" name="itdTimeHour" id="itdTimeHour" />
+
+                    <input type="hidden" value="08" name="itdTimeMinute" id="itdTimeMinute" />
+
+                    <input type="hidden" id="name_origin" name="name_origin" value="2600 S River Rd, Des Plaines, 60018" />
+
+
+
+                    <input type="hidden" name="name_destination" id="name_destination" value="1850 W Surrey Park Ln, Arlington Heights" />
+
+                    <input type="hidden" value="arr" name="itdTripDateTimeDepArr" id="itdTripDateTimeDepArr" />
+
+                    <span id="ctl00_ctl08_lblLink" style="display:none;">http://elb-jpinstances-1463028547.us-east-1.elb.amazonaws.com/ccg3/XSLT_TRIP_REQUEST2</span>
+                    <input type="image" name="ctl00$ctl08$imgRTAMDV" id="ctl00_ctl08_imgRTAMDV" title="use RTA Trip Planner" src="/images/global/btn_goroo.png" alt="use RTA Trip Planner" onclick="return submitMDV();" style="border-width:0px;border-style: none;" />
+
+
+                </div>
+                <br />
+                <a href="/travel_information/trip_planner.aspx">About trip planners (and more options)..</a>
+            </div>
+        </div>
+        <div class="rrmodbtm">
+            &nbsp;</div>
+    
+</div>
+</div>
+
+<div class="rrmodwrpr">
+    <h3>
+        <a href="/travel_information/systemalerts.aspx">System Status</a></h3>
+    <div class="rrmodtop">
+        &nbsp;</div>
+    <div class="rrmodbdy">
+        <div class="rrmodcontent">
+            
+            <div class="rrmodinrwrpr">
+                <h4>
+                    <span style="color: #000000;">Trains:</span></h4>
+                
+                        <table cellspacing="0" cellpadding="0" border="0" class="tblsystatus" summary="System status">
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl01_thRailName" scope="row" style="background-color:#c60c30;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/redline.aspx">Red Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl01_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl02_thRailName" scope="row" style="background-color:#00a1de;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/blueline.aspx">Blue Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl02_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl03_thRailName" scope="row" style="background-color:#62361b;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/brownline.aspx">Brown Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl03_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl04_thRailName" scope="row" style="background-color:#009b3a;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/greenline.aspx">Green Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl04_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl05_thRailName" scope="row" style="background-color:#f9461c;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/orangeline.aspx">Orange Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl05_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl06_thRailName" scope="row" style="background-color:#522398;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/purpleline.aspx">Purple Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl06_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl07_thRailName" scope="row" style="background-color:#e27ea6;" class="rlngeneric notranslate">
+                                <a style="color:#ffffff;" href="/riding_cta/systemguide/pinkline.aspx">Pink Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl07_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        <tr>
+                            <th id="_9df7e7522f6_rptRailStatus_ctl08_thRailName" scope="row" style="background-color:#f9e300;" class="rlngeneric notranslate">
+                                <a style="color:#000000;" href="/riding_cta/systemguide/yellowline.aspx">Yellow Line</a></th>
+
+                            <td id="_9df7e7522f6_rptRailStatus_ctl08_tdStatus" class="normal">
+                                Normal Service</td>
+
+                        </tr>
+                    
+                        </table>
+            </div>
+            <div class="rrmodinrwrpr">
+                <h4>
+                    <span style="color: #000000;">Buses:</span></h4>
+                Routes with Current Alerts (<a href="/travel_information/bus_status.aspx">View All</a>):
+                <br />
+                <div align="left">
+                    
+                    <table id="_9df7e7522f6_dlBusAlerts" cellspacing="0" cellpadding="2" border="0" style="width:100%;border-collapse:collapse;">
+	<tr>
+		<td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=158"><b>1</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=159"><b>2</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=160"><b>3</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=162"><b>4</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=164"><b>N5</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=165"><b>6</b></a>
+                        </td>
+	</tr><tr>
+		<td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=173"><b>12</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=175"><b>15</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=183"><b>26</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=187"><b>30</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=190"><b>35</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=224"><b>63</b></a>
+                        </td>
+	</tr><tr>
+		<td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=227"><b>65</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=229"><b>67</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=232"><b>70</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=233"><b>71</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=235"><b>73</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=238"><b>76</b></a>
+                        </td>
+	</tr><tr>
+		<td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=253"><b>90</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=264"><b>100</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=265"><b>103</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=266"><b>106</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=277"><b>126</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=281"><b>135</b></a>
+                        </td>
+	</tr><tr>
+		<td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=288"><b>148</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=293"><b>157</b></a>
+                        </td><td style="width:40px;">
+                            <a href="/riding_cta/busroute.aspx?RouteId=299"><b>172</b></a>
+                        </td><td></td><td></td><td></td>
+	</tr>
+</table>
+                </div>
+            </div>
+            <div class="rrmodinrwrpr">
+                <h4>
+                    <span style="color: #000000;">More:</span></h4>
+                <div class="larger">
+                    <div class="fltlft">
+                        <a href="/travel_information/systemalerts.aspx">See all Alerts</a></div>
+                    <div class="fltrt">
+                        <a href="/travel_information/accessibility_status.aspx">Accessibility</a></div>
+                    <div class="clear">
+                        &nbsp;</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="rrmodbtm">
+        &nbsp;</div>
+</div>
+
+				</div>
+				<div class="clear">&nbsp;</div>
+			</div>
+		<!-- end layout -->
+		</div>
+	<!-- end core -->
+
+
+	<!-- start footer -->
+		<div class="ftrwrpr">
+			<div id="_32c265e789a8_divFooter" class="ftrinrwrpr">
+    <div class="ftrlnks">
+        &copy;2017
+        Chicago Transit Authority<span class="pipe">|</span><a href="/terms.aspx">Terms of Use</a><span class="pipe">|</span><a href="/privacy.aspx">Privacy</a><span class="pipe">|</span><a href="/contact/unsubscribe.aspx">Unsubscribe</a><span class="pipe">|</span><a href="/careers">Careers</a><span class="pipe">|</span><a href="/contact/default.aspx">Contact Us</a><span class="pipe">|</span><a href="/rss/default.aspx">RSS</a><span class="pipe">|</span><a href="/social">Social Media</a>
+    </div>
+    <div class="ftrlang">
+        
+<img style="width:11px;" alt="international globe" src="/images/global/icon_intlglobe.gif" />&nbsp;<b><a href="/guide/default.aspx">Languages</a></b>
+
+        [<b><a href="javascript:window.open('http://www.transitchicago.com/default.aspx','_top');">En</a></b>]
+
+    
+        [<b><a href="javascript:window.open('http://www.transitchicago.com/guide/pl/default.aspx','_top');">Pl</a></b>]
+
+    
+        [<b><a href="javascript:window.open('http://www.transitchicago.com/guide/zh/default.aspx','_top');">Zh</a></b>]
+
+    
+        [<b><a href="javascript:window.open('http://www.transitchicago.com/guide/es/default.aspx','_top');">Es</a></b>]
+
+    
+
+    </div>
+    <div class="clear">
+        &nbsp;</div>
+    <div class="ftrbnrs">
+        <img src="/images/global/ftr-icobnr-phone.gif" style="width: 152px; height: 36px;
+            border-style: none;" alt="Phone: 1-888-YOUR-CTA" />
+        <img src="/images/global/ftr-icobnr-tty_new.gif" style="width: 220px; height: 36px; border-style: none;"
+            alt="TTY: 1-888-CTA-TTY1" />
+        <a href="/contact/email.aspx">
+            <img src="/images/global/ftr-icobnr-email.gif" style="width: 218px; height: 36px;
+                border-style: none;" alt="E-mail: feedback@transitchicago.com" /></a>
+    </div>
+    <div class="clear">
+        &nbsp;</div>
+</div>
+
+
+		</div>
+	<!-- end footer -->
+  
+	</div>
+</div>
+
+ 
+
+<script type="text/javascript">
+//<![CDATA[
+Sys.Application.initialize();
+//]]>
+</script>
+</form>
+ 
+<script type="text/javascript">
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+</script>
+<script type="text/javascript">
+var pageTracker = _gat._getTracker("UA-6691317-1");
+pageTracker._initData();
+pageTracker._trackPageview();
+</script>
+</body>
+</html>

--- a/tests/test_chi_transit.py
+++ b/tests/test_chi_transit.py
@@ -31,7 +31,7 @@ def test_start_time():
 
 
 def test_start_time_after_mtg():
-    assert parsed_items[1]['start_time'] == '2017-11-15T00:00:00-06:00'
+    assert parsed_items[1]['start_time'] == '2017-11-15T14:00:00-06:00'
 
 
 def test_classification():

--- a/tests/test_chi_transit.py
+++ b/tests/test_chi_transit.py
@@ -1,0 +1,76 @@
+import pytest
+
+from freezegun import freeze_time
+from tests.utils import file_response
+from documenters_aggregator.spiders.chi_transit import ChiTransitSpider
+
+freezer = freeze_time('2017-11-10 12:00:01')
+freezer.start()
+
+test_response = file_response('files/chi_transit.html')
+spider = ChiTransitSpider()
+parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
+
+freezer.stop()
+
+
+def test_name():
+    assert parsed_items[0]['name'] == 'Committee on Strategic Planning & Service Delivery'
+    assert parsed_items[1]['name'] == 'Committee on Finance, Audit & Budget'
+    assert parsed_items[2]['name'] == 'Regular Board Meeting of Chicago Transit Board'
+
+
+def test_description():
+    assert parsed_items[0]['description'] == 'Transit Board Committee Meetings -  Meeting Notice: http://www.transitchicago.com/assets\\1\\agendas_minutes\\Nov2017_-_Notice_-_Strategic_Planning_Cmte.pdf'
+    assert parsed_items[1]['description'] == 'Transit Board Committee Meetings -  Meeting Notice: http://www.transitchicago.com/assets\\1\\agendas_minutes\\Nov2017_-_Notice_-_FAB.pdf'
+    assert parsed_items[2]['description'] == 'Transit Board Meetings -  Meeting Notice: http://www.transitchicago.com/assets\\1\\agendas_minutes\\Nov2017_-_Notice_-_Regular_Brd.pdf'
+
+
+def test_start_time():
+    assert parsed_items[0]['start_time'] == '2017-11-15T14:00:00-06:00'
+
+
+def test_start_time_after_mtg():
+    assert parsed_items[1]['start_time'] == '2017-11-15T00:00:00-06:00'
+
+
+def test_classification():
+    assert parsed_items[0]['classification'] == 'Transit Board Committee Meetings'
+    assert parsed_items[2]['classification'] == 'Transit Board Meetings'
+
+
+def test_id():
+    assert parsed_items[0]['id'] == '2017-11-15-committee-on-strategic-planning-service-delivery'
+    assert parsed_items[2]['id'] == '2017-11-15-regular-board-meeting-of-chicago-transit-board'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_end_time(item):
+    assert item['end_time'] is None
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_all_day(item):
+    assert item['all_day'] is False
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_status(item):
+    assert item['status'] == 'tentative'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_location(item):
+    assert item['location'] == {
+        'url': 'http://www.transitchicago.com',
+        'name': '567 West Lake Street, 2nd Floor, Boardroom, Chicago, IL',
+        'coordinates': {
+            'latitude': 41.88528,
+            'longitude': -87.64235,
+        },
+    }
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test__type(item):
+    assert parsed_items[0]['_type'] == 'event'


### PR DESCRIPTION
Adding a spider for the Chicago Transit Authority board. It's mostly straightforward, but there's one part I have a question on.

On the [events page](http://www.transitchicago.com/agendaminute/default.aspx?F_OrderBy=MeetingDate+DESC), one type of meeting's start time is consistently marked "Immediately following Cmt Strategic Planning & Svs". I'm just setting the date on those and leaving the time at midnight, but would it be better to add a time an hour or so after the previous meeting?