### PR TITLE
Raise base logging level

### DIFF
--- a/documenters_aggregator/settings.py
+++ b/documenters_aggregator/settings.py
@@ -8,6 +8,7 @@
 #     http://doc.scrapy.org/en/latest/topics/settings.html
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
+import logging
 
 BOT_NAME = 'documenters_aggregator'
 
@@ -104,3 +105,4 @@ CLOSESPIDER_ERRORCOUNT = 5
 #HTTPCACHE_DIR = 'httpcache'
 #HTTPCACHE_IGNORE_HTTP_CODES = []
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+LOG_LEVEL = logging.INFO


### PR DESCRIPTION
Fixes #178.

Specifically, it's worth noting that the debug messages were being caused by `from deploy import ecs` in `tasks.py`, so if we wanted to be more surgical about this and put something specific in `deploy/ecs.py` then I can take another look.