### PR TITLE
Standardize ids

### DIFF
--- a/deploy/prod_settings.py.example
+++ b/deploy/prod_settings.py.example
@@ -30,12 +30,12 @@ COOKIES_ENABLED = False
 # One of:
 # * documenters_aggregator.pipelines.DocumentersAggregatorLoggingPipeline,
 # * documenters_aggregator.pipelines.DocumentersAggregatorSQLAlchemyPipeline,
-# * documenters_aggregator.pipelines.DocumentersAggregatorAirtablePipeline
+# * documenters_aggregator.pipelines.AirtablePipeline
 #
 # Or define your own.
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    'documenters_aggregator.pipelines.DocumentersAggregatorAirtablePipeline': 300,
+    'documenters_aggregator.pipelines.AirtablePipeline': 300,
 }
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)

--- a/documenters_aggregator/pipelines/airtable.py
+++ b/documenters_aggregator/pipelines/airtable.py
@@ -43,7 +43,7 @@ class AirtablePipeline(object):
         new_item['location_address'] = get_key(new_item, 'location.address')
         new_item['location_latitude'] = get_key(new_item, 'location.coordinates.latitude')
         new_item['location_longitude'] = get_key(new_item, 'location.coordinates.longitude')
-        new_item['timezone'] = 'America/Chicago' # TODO have this passed in by the spiders
+        new_item['timezone'] = 'America/Chicago'  # TODO have this passed in by the spiders
         new_item['all_day'] = 'false'
         new_item['agency_name'] = spider.long_name
 

--- a/documenters_aggregator/spider.py
+++ b/documenters_aggregator/spider.py
@@ -5,11 +5,16 @@ import re
 from datetime import datetime
 from pytz import timezone
 
+from inflector import Inflector, English
+
 class Spider(scrapy.Spider):
+    inflector = Inflector(English)
+
     def _generate_id(self, item, data, start_time):
         """
         Calulate ID. ID must be unique within the data source being scraped.
         """
         name = self.inflector.underscore(data['name'])
+        id = data.get('id', 'x')
         parts = [self.name, datetime.strftime(start_time, '%Y%m%d%H%M'), 'x', name]
         return '/'.join(parts)

--- a/documenters_aggregator/spider.py
+++ b/documenters_aggregator/spider.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import scrapy
+import re
+
+from datetime import datetime
+from pytz import timezone
+
+class Spider(scrapy.Spider):
+    def _generate_id(self, item, data, start_time):
+        """
+        Calulate ID. ID must be unique within the data source being scraped.
+        """
+        name = self.inflector.underscore(data['name'])
+        parts = [self.name, datetime.strftime(start_time, '%Y%m%d%H%M'), 'x', name]
+        return '/'.join(parts)

--- a/documenters_aggregator/spider.py
+++ b/documenters_aggregator/spider.py
@@ -16,5 +16,5 @@ class Spider(scrapy.Spider):
         """
         name = self.inflector.underscore(data['name'])
         id = data.get('id', 'x')
-        parts = [self.name, datetime.strftime(start_time, '%Y%m%d%H%M'), 'x', name]
+        parts = [self.name, datetime.strftime(start_time, '%Y%m%d%H%M'), id, name]
         return '/'.join(parts)

--- a/documenters_aggregator/spider.py
+++ b/documenters_aggregator/spider.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-import scrapy
-import re
 
 from datetime import datetime
-from pytz import timezone
 
 from inflector import Inflector, English
+import scrapy
+
 
 class Spider(scrapy.Spider):
     inflector = Inflector(English)
@@ -15,6 +14,6 @@ class Spider(scrapy.Spider):
         Calulate ID. ID must be unique within the data source being scraped.
         """
         name = self.inflector.underscore(data['name'])
-        id = data.get('id', 'x')
+        id = data.get('id', 'x').replace('/', '-')
         parts = [self.name, datetime.strftime(start_time, '%Y%m%d%H%M'), id, name]
         return '/'.join(parts)

--- a/documenters_aggregator/spiders/chi_animal.py
+++ b/documenters_aggregator/spiders/chi_animal.py
@@ -8,6 +8,7 @@ from pytz import timezone
 
 from documenters_aggregator.spider import Spider
 
+
 class Chi_animalSpider(Spider):
     name = 'chi_animal'
     long_name = 'Animal Care and Control Commission'

--- a/documenters_aggregator/spiders/chi_buildings.py
+++ b/documenters_aggregator/spiders/chi_buildings.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta
 import scrapy
 from documenters_aggregator.spider import Spider
 
+
 class Chi_buildingsSpider(Spider):
     name = 'chi_buildings'
     long_name = 'Public Building Commission of Chicago'

--- a/documenters_aggregator/spiders/chi_city_college.py
+++ b/documenters_aggregator/spiders/chi_city_college.py
@@ -11,6 +11,7 @@ from pytz import timezone
 
 from documenters_aggregator.spider import Spider
 
+
 class Chi_cityCollegeSpider(Spider):
     name = 'chi_city_college'
     long_name = 'City College of Chicago'

--- a/documenters_aggregator/spiders/chi_city_college.py
+++ b/documenters_aggregator/spiders/chi_city_college.py
@@ -10,8 +10,8 @@ from datetime import datetime
 from pytz import timezone
 
 
-class CccSpider(scrapy.Spider):
-    name = 'ccc'
+class Chi_cityCollegeSpider(scrapy.Spider):
+    name = 'chi_city_college'
     long_name = 'City College of Chicago'
     allowed_domains = ['http://www.ccc.edu/departments/Pages/Board-of-Trustees.aspx']
     start_urls = ['http://www.ccc.edu/departments/Pages/Board-of-Trustees.aspx']

--- a/documenters_aggregator/spiders/chi_parks.py
+++ b/documenters_aggregator/spiders/chi_parks.py
@@ -9,7 +9,6 @@ import urllib3
 from datetime import datetime
 from pytz import timezone
 from legistar.events import LegistarEventsScraper
-from inflector import Inflector, English
 
 from documenters_aggregator.spider import Spider
 
@@ -19,8 +18,6 @@ class Chi_parksSpider(Spider):
     START_URL = 'https://chicagoparkdistrict.legistar.com'
     allowed_domains = ['chicagoparkdistrict.legistar.com']
     start_urls = [START_URL]
-
-    inflector = Inflector(English)
 
     def parse(self, response):
         """

--- a/documenters_aggregator/spiders/chi_parks.py
+++ b/documenters_aggregator/spiders/chi_parks.py
@@ -12,6 +12,7 @@ from legistar.events import LegistarEventsScraper
 
 from documenters_aggregator.spider import Spider
 
+
 class Chi_parksSpider(Spider):
     name = 'chi_parks'
     long_name = 'Chicago Park District'

--- a/documenters_aggregator/spiders/chi_schools.py
+++ b/documenters_aggregator/spiders/chi_schools.py
@@ -6,7 +6,7 @@ from pytz import timezone
 
 
 class Chi_schoolsSpider(scrapy.Spider):
-    name = 'cpsboe'
+    name = 'chi_schools'
     long_name = 'Chicago Public Schools Board of Education'
     allowed_domains = ['www.cpsboe.org']
     start_urls = ['http://www.cpsboe.org/meetings/planning-calendar']

--- a/documenters_aggregator/spiders/chi_schools.py
+++ b/documenters_aggregator/spiders/chi_schools.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-import scrapy
-
 from datetime import datetime
 from pytz import timezone
 
+from documenters_aggregator.spider import Spider
 
-class Chi_schoolsSpider(scrapy.Spider):
+
+class Chi_schoolsSpider(Spider):
     name = 'chi_schools'
     long_name = 'Chicago Public Schools Board of Education'
     allowed_domains = ['www.cpsboe.org']
@@ -16,26 +16,20 @@ class Chi_schoolsSpider(scrapy.Spider):
         for item in response.css('#content-primary tr')[1:]:
             start_time = self._parse_start_time(item)
             if start_time is not None:
-                yield {
+                start_time, start_time_str = self._parse_start_time(item)
+                data = {
                     '_type': 'event',
-                    'id': self._parse_id(item),
-                    'name': 'Chicago Board of Education Monthly Meeting',
+                    'name': 'Monthly Board Meeting',
                     'description': self._parse_description(item),
                     'classification': self._parse_classification(item),
-                    'start_time': self._parse_start_time(item),
+                    'start_time': start_time_str,
                     'all_day': self._parse_all_day(item),
                     'status': self._parse_status(item),
                     'location': self._parse_location(item)
-
                 }
+                data['id'] = self._generate_id(item, data, start_time)
 
-    def _parse_id(self, item):
-        """
-        Generate an ID by converting the date and time to an integer.
-        i.e. 'July 27, 2016 at 10:30am' becomes '201707261030'
-        """
-        text_list = self._remove_line_breaks(item.css('::text').extract())
-        return text_list[0].replace(' ', '')
+                yield data
 
     def _remove_line_breaks(self, collection):
         return [x.strip() for x in collection if x.strip() != '']
@@ -62,7 +56,8 @@ class Chi_schoolsSpider(scrapy.Spider):
         try:
             date = datetime.strptime(date_string, '%B %d %Y %I %M %p')
             tz = timezone('America/Chicago')
-            return tz.localize(date).isoformat()
+            date_tz = tz.localize(date)
+            return (date_tz, date_tz.isoformat())
         except:
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ hyperlink==17.3.0
 icalendar==3.11.7
 idna==2.6
 incremental==17.5.0
+Inflector==2.0.11
 invoke==0.20.1
 ipdb==0.10.3
 ipython==6.1.0

--- a/tests/test_chi_animal.py
+++ b/tests/test_chi_animal.py
@@ -17,4 +17,4 @@ def test_name():
 
 
 def test_start_time():
-    assert parsed_items[0]['start_time'] == date(2017, 9, 21)
+    assert parsed_items[0]['start_time'] == '2017-09-21T00:00:00-05:00'

--- a/tests/test_chi_animal.py
+++ b/tests/test_chi_animal.py
@@ -1,4 +1,3 @@
-from datetime import date
 from tests.utils import file_response
 from documenters_aggregator.spiders.chi_animal import Chi_animalSpider
 

--- a/tests/test_chi_buildings.py
+++ b/tests/test_chi_buildings.py
@@ -42,7 +42,7 @@ def test_end_time(item):
 
 
 def test_id():
-    assert parsed_items[0]['id'] == 'PBCC2176'
+    assert parsed_items[0]['id'] == 'chi_buildings/201710160000/2176/daley_plaza_italian_exhibit'
 
 
 def test_all_day():

--- a/tests/test_chi_city_college.py
+++ b/tests/test_chi_city_college.py
@@ -20,7 +20,7 @@ def test_end_time():
 
 
 def test_id():
-    assert item['id'] == 'November2017RegularBoardMeeting'
+    assert item['id'] == 'chi_city_college/201711020900/x/november_2017_regular_board_meeting'
 
 
 def test_all_day():

--- a/tests/test_chi_city_college.py
+++ b/tests/test_chi_city_college.py
@@ -1,9 +1,9 @@
 from tests.utils import file_response
-from documenters_aggregator.spiders.ccc import CccSpider
+from documenters_aggregator.spiders.chi_city_college import Chi_cityCollegeSpider
 
 
 test_response = file_response('files/ccc_event.html')
-spider = CccSpider()
+spider = Chi_cityCollegeSpider()
 item = spider.parse_event_page(test_response)
 
 

--- a/tests/test_chi_parks.py
+++ b/tests/test_chi_parks.py
@@ -35,10 +35,10 @@ def test_start_time():
 
 
 def test_id():
-    assert parsed_items[0]['id'] == 'BoardofCommissioners12132017'
-    assert parsed_items[1]['id'] == 'PublicHearing1262017'
-    assert parsed_items[3]['id'] == 'SpecialMeeting10202017'
-    assert parsed_items[6]['id'] == 'BudgetForum9192017'
+    assert parsed_items[0]['id'] == 'chi_parks/201712131530/x/board_of_commissioners'
+    assert parsed_items[1]['id'] == 'chi_parks/201712061530/x/public_hearing'
+    assert parsed_items[3]['id'] == 'chi_parks/201710201330/x/special_meeting'
+    assert parsed_items[6]['id'] == 'chi_parks/201709191800/x/budget_forum'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_chi_policeboard.py
+++ b/tests/test_chi_policeboard.py
@@ -28,7 +28,7 @@ def test_end_time(item):
 
 
 def test_id():
-    assert parsed_items[8]['id'] == 'CPBSeptember18'
+    assert parsed_items[8]['id'] == 'chi_policeboard/201709181930/x/public_meetings_of_the_police_board'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_chi_schools.py
+++ b/tests/test_chi_schools.py
@@ -19,12 +19,12 @@ def test_type(item):
 
 
 def test_id():
-    assert parsed_items[0]['id'] == 'July26,2017at10:30am'
+    assert parsed_items[0]['id'] == 'chi_schools/201707261030/x/monthly_board_meeting'
 
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_name(item):
-    assert item['name'] == 'Chicago Board of Education Monthly Meeting'
+    assert item['name'] == 'Monthly Board Meeting'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_cityclerk.py
+++ b/tests/test_cityclerk.py
@@ -22,11 +22,11 @@ def test_start_time():
 
 
 def test_end_time():
-    assert parsed_items[0]['end_time'] == ''
+    assert parsed_items[0]['end_time'] is None
 
 
 def test_id():
-    assert parsed_items[0]['id'] == 'ocd-event/86094f46-cf45-46f8-89e2-0bf783e7aa12'
+    assert parsed_items[0]['id'] == 'cityclerk/201710161500/ocd-event-86094f46-cf45-46f8-89e2-0bf783e7aa12/joint_committee_finance_transportation_and_public_way'
 
 
 def test_all_day():
@@ -34,7 +34,7 @@ def test_all_day():
 
 
 def test_classification():
-    assert parsed_items[0]['classification'] == 'event'
+    assert parsed_items[0]['classification'] is None
 
 
 def test_status():


### PR DESCRIPTION
This pull request changes the way we generate events ids to a new scheme that is more human- and machine-readable. (We should always treat ids as opaque, and I thought about hashing the result to enforce this, but that seemed overbearing at this point).

I want to get this locked down so that we can start using the system. We can easily make a change to any of the other values for an event later on, but getting the identifiers right needs to be done now as changing their format later will be extremely painful.

Most of the spiders are using their own heuristic to come up with an event identifier (usually using the date and sometimes the event name), as there is often not a publicly-visible ID for each event.

This set of patches will (when complete) update all spiders to use IDs in the following format:

`<spider-name>/<YYYYMMddhhmm>/<id-or-x>/<underscored-event-name>`

This will give us IDs such as:

`chi_buildings/201710161230/2176/daley_plaza_italian_exhibit`

when the event has a useful id exposed, and like this when it does not:

`chi_buildings/201710161230/x/daley_plaza_italian_exhibit`

This scheme achieves identifiers that are just as unique as the prior scheme, but with a regular format and only using a-z, 0-9, /, and _.