### PR TITLE
WIP: include a validation task when travis runs

### DIFF
--- a/documenters_aggregator/pipelines/__init__.py
+++ b/documenters_aggregator/pipelines/__init__.py
@@ -3,6 +3,7 @@ from .geocoder import GeocoderPipeline
 from .LoggingPipeline import DocumentersAggregatorLoggingPipeline
 from .sqlalchemy import DocumentersAggregatorSQLAlchemyPipeline
 from .ValidationPipeline import ValidationPipeline
+from .github import GithubValidationPipeline
 
 
 __all__ = (
@@ -10,5 +11,6 @@ __all__ = (
     'AirtablePipeline',
     'GeocoderPipeline',
     'DocumentersAggregatorSQLAlchemyPipeline',
-    'ValidationPipeline'
+    'ValidationPipeline',
+    'GithubValidationPipeline'
 )

--- a/documenters_aggregator/pipelines/github.py
+++ b/documenters_aggregator/pipelines/github.py
@@ -1,0 +1,99 @@
+import re
+from datetime import datetime
+from pytz import timezone
+
+class GithubValidationPipeline(object):
+    NULL_VALUES = [None, '']
+    SCHEMA = {
+        '_type': {'required': True, 'type': str, 'values': ['event']},
+        'id': {'required': True, 'type': str, 'format_str': '.+/\d{12}/.+/.+'},
+        'name': {'required': True, 'type': str},
+        'description': {'required': False, 'type': str},
+        'classification': {'required': True, 'type': str},
+        'start_time': {'required': True, 'type': str, 'format_str': '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-0(5|6):00'},
+        'end_time': {'required': False, 'type': str, 'format_str': '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-0(5|6):00'},
+        'timezone': {'required': True, 'type': str},
+        'all_day': {'required': True, 'type': bool},
+        'location': {'required': True, 'type': dict},
+        'sources': {'required': True, 'type': list}
+    }
+    LOCATION_SCHEMA = {
+        'url': {'required': False, 'type': str},
+        'name': {'required': True, 'type': str},
+        'address': {'required': False, 'type': str},
+        'coordinates': {'required': True, 'type': dict}
+    }
+    COORDINATES_SCHEMA = {
+        'latitude': {'required': False, 'type': str},
+        'longitude': {'required': False, 'type': str}
+    }
+    SOURCES_SCHEMA = {
+        'url': {'required': True, 'type': str},
+        'note': {'required': False, 'type': str}
+    }
+
+    def process_item(self, item, spider):
+        '''
+        Adds validation fields to an item.
+        '''
+        try:
+            tz = timezone(item['timezone'])
+            start_time = item['start_time']
+            if start_time < tz.localize(datetime.now()).isoformat():
+                return {}
+        except:
+            pass
+
+        item_location = item.get('location', {})
+        if not isinstance(item_location, dict):
+            item_location = {}
+        item_coordinates = item.get('location', {'coordinates': {}}).get('coordinates', {})
+        if not isinstance(item_coordinates, dict):
+            item_coordinates = {}
+
+        validation_record = self._validate_against_schema(item, self.SCHEMA)
+        validation_record.update(self._validate_against_schema(item_location, self.LOCATION_SCHEMA, 'loc'))
+        validation_record.update(self._validate_against_schema(item_coordinates, self.COORDINATES_SCHEMA, 'coord'))
+
+        is_sources_valid = validation_record['val_sources']
+        for source in item.get('sources', []):
+            source_validation = self._validate_against_schema(source, self.SOURCES_SCHEMA)
+            is_sources_valid = is_sources_valid and all(source_validation.values())
+        validation_record.update({'val_sources': str(is_sources_valid)})
+
+        item.update(validation_record)
+        return item
+
+    def _validate_against_schema(self, item, schema, prefix=''):
+        """
+        For each field in schema, create a dictionary entry
+        (key='val_{field}': value=True/False) where the value
+        indicates whether or not item[field] conforms to the schema.
+        """
+        validation_record = {}
+        for field in schema:
+            new_key = 'val_{0}_{1}'.format(prefix, field).replace('__', '_')
+            is_valid = True
+            is_required = schema[field]['required']
+            if not is_required and (item.get(field, None) in self.NULL_VALUES):
+                is_valid = True
+            else:
+                if is_required:
+                    is_valid = not (item.get(field, None) in self.NULL_VALUES)
+                if 'type' in schema[field]:
+                    correct_type = isinstance(item.get(field, None), schema[field]['type'])
+                    is_valid = is_valid and correct_type
+                if 'values' in schema[field]:
+                    in_values = (item.get(field, None) in schema[field]['values'])
+                    is_valid = is_valid and in_values
+                if 'format_str' in schema[field]:
+                    pattern = re.compile(schema[field]['format_str'])
+                    try:
+                        match = re.match(pattern, item.get(field, ''))
+                    except TypeError:
+                        is_valid = False
+                    else:
+                        if not match:
+                            is_valid = False
+            validation_record[new_key] = int(is_valid)  # airtable ignores boolean False's
+        return validation_record

--- a/documenters_aggregator/settings.py
+++ b/documenters_aggregator/settings.py
@@ -35,7 +35,7 @@ COOKIES_ENABLED = False
 # Or define your own.
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    'documenters_aggregator.pipelines.ValidationPipeline': 300,
+    'documenters_aggregator.pipelines.GithubValidationPipeline': 300,
 }
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ lxml==4.0.0
 -e git+https://github.com/duydo/python-mapzen.git@80f59d1f6fcc3a3c1133ead5063fe7562f0180ac#egg=mapzen
 MarkupSafe==1.0
 opencivicdata==2.0.0
+pandas==0.21.0
 parsel==1.2.0
 pexpect==4.2.1
 pickleshare==0.7.4

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,8 @@
 import requests
 import os
 import time
+import json
+import pandas as pd
 
 from deploy import ecs
 from invoke import Collection, task, run
@@ -155,8 +157,53 @@ def _get_domains(start_urls):
     return domains
 
 
+@task
+def validate_new_spiders(ctx):
+    """
+    Validates new spiders on Travis CI.
+
+    Gets the added or modified spiders between a
+    pull request branch's HEAD and the branch 
+    being merged into. Runs the new spiders and
+    saves the scraped items. Validates the
+    newly scraped items.
+    """
+    new_files = run(('git diff --name-only --diff-filter=AM HEAD...$TRAVIS_BRANCH'
+                     '| grep .*documenters_aggregator/spiders/.*\.py')).stdout
+    # new_files = run(('git diff --name-only HEAD...test_branch'
+    #                 '| grep .*documenters_aggregator/spiders/.*\.py')).stdout
+    spider_names = [x.split('/')[-1][:-3] for x in new_files.split('\n') if x]
+    for spider in spider_names:
+        run('scrapy crawl {0} -o {0}.json --loglevel=ERROR'.format(spider))
+        _validate_spider(spider)
+
+def _validate_spider(spider):
+    """
+    Validates scraped items from a spider.
+    Passes if >=90% of the scraped items
+    conform to the schema.
+    """
+    scraped_items = json.load(open('{0}.json'.format(spider)))
+    validated_items = [{k: v for k, v in item.items() if k.startswith('val_')} for item in scraped_items]
+    validation_summary = pd.DataFrame(validated_items).mean()
+
+    print('\n------------Validation Summary for: {0}---------------\n'.format(spider))
+    print(validation_summary)
+
+    try:
+        assert all([x >= 0.9 for x in validation_summary.tolist()])
+    except AssertionError as e:
+        message = ('Less than 90% of the scraped items from {0} passed validation. '
+            'See the validation summary printed in stdout, and check that the '
+            'scraped items conform to the events schema at: '
+            'https://city-bureau.gitbooks.io/documenters-event-aggregator/'
+            'event-schema.html').format(spider)
+        raise Exception(message) from e
+
+
 # Python invoke namespace (http://docs.pyinvoke.org/en/0.11.0/concepts/namespaces.html#nesting-collections)
 ns = Collection()
 ns.add_task(genspider)
 ns.add_task(runtests)
+ns.add_task(validate_new_spiders)
 ns.add_collection(ecs, 'ecs')


### PR DESCRIPTION
@eads @jim, I'd like to include a validation task on Travis that does the following:
- checks if there are any new or modified spiders in the pull request
- runs those spiders, runs the scraped items through a GithubValidationPipeline, and saves them
- if <90% of the newly scraped items from a spider passes validation, then throw an error on Travis

Does this seem like a good idea? I think it would be nice to have some validation show up on Travis when new pull requests are made. Then again, running the spiders during CI adds some uncertainty...


Here is some code that almost works. Some problems:
- Calling `scrapy crawl` inside of an invoke task throws an import error: no module called documenters_aggregator
- `invoke -l` now gives a bunch of scrapy output...
