### PR TITLE
Capitalize location_name, N/A in Airtable

### DIFF
--- a/documenters_aggregator/pipelines/airtable.py
+++ b/documenters_aggregator/pipelines/airtable.py
@@ -71,7 +71,9 @@ class AirtablePipeline(object):
 
     def _format_values(self, k, v):
         if ((v is None) or v == '') and (k not in ['start_time', 'end_time']):
-            return 'n/a'
+            return 'N/A'
+        if k == 'location_name':
+            return ' '.join([w.capitalize() for w in v.split(' ')])
         if isinstance(v, bool):
             return int(v)
         return v


### PR DESCRIPTION
Fixes #209. Airtable should show "N/A" instead of "n/a" and location name strings should be title-cased so that "6th district police station" becomes 6th District Police Station".

I tried using the Inflector library initially, but for the "6th district police station" example it returns "6Th District Police Station". Looking at the source of their `titleize` method, it's mostly just calling Python's `title()` which converts ordinal number string like "6th" to "6Th". Calling `capitalize()` manually isn't too much more complex and avoids that issue